### PR TITLE
Add missing space to user exception message

### DIFF
--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipException.cs
@@ -11,7 +11,7 @@ public class SharpSevenZipException : Exception
     /// <summary>
     /// The message for thrown user exceptions.
     /// </summary>
-    internal const string USER_EXCEPTION_MESSAGE = "The extraction was successful but" +
+    internal const string USER_EXCEPTION_MESSAGE = "The extraction was successful but " +
         "some exceptions were thrown in your events. Check UserExceptions for details.";
 
     /// <summary>


### PR DESCRIPTION
This is a tiny little issue related to a missing space in this exception message which would appear as follows:

```
Unhandled exception. SharpSevenZip.Exceptions.SharpSevenZipException: The extraction was successful butsome exceptions were thrown in your events. Check UserExceptions for details.
```

Notice the space missing between `but` and `some`.

Cheers
Fotis