### PR TITLE
Fix DLL loading failure caused by AppContext.BaseDirectory path handling

### DIFF
--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipLibraryManager.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipLibraryManager.cs
@@ -37,7 +37,7 @@ internal static class SharpSevenZipLibraryManager
             return null;
         }
 
-        return Path.Combine(location!, Environment.Is64BitProcess ? "x64" : "x86", "7z.dll");
+        return Path.Combine(location, Environment.Is64BitProcess ? "x64" : "x86", "7z.dll");
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #14 

On certain test runners, `AppContext.BaseDirectory` does not end with a trailing `\`.  
When `Path.GetDirectoryName()` is called on such a value, it returns the **parent** directory of the application instead of the expected base directory, causing DLL loading to fail.

This PR removes the `Path.GetDirectoryName()` call, so that the trailing directory separator (if present or not) is handled correctly by the framework.

### References

[Similar handling in squid-box](https://github.com/squid-box/SevenZipSharp/blob/master/SevenZip/LibraryManager.cs#L50
) always resolves the expected directory because `Path.GetDirectoryName()` is called on the file path (assembly location).