### PR TITLE
[BUGFIX] `ExtractStream` should handle end of stream explicitly

### DIFF
--- a/SharpSevenZip/SharpSevenZip/ExtractStream.cs
+++ b/SharpSevenZip/SharpSevenZip/ExtractStream.cs
@@ -15,10 +15,20 @@ internal class ExtractStream : Stream
     private long _totalWriteSize = 0;
     private long _unpackedSize = -1;
     private bool _isOpen = true;
+    private bool _isEndOfStream = false;
+
     private readonly object _lock = new();
 
     public ExtractStream()
     {
+    }
+
+    public void SignalEndOfStream()
+    {
+        lock (_lock)
+        {
+            _isEndOfStream = true;
+        }
     }
 
     public override bool CanRead => _isOpen;
@@ -58,13 +68,11 @@ internal class ExtractStream : Stream
 
                 long maxTotalRequestedSize = Math.Min(_totalRequestedSize, _unpackedSize);
 
-                if (_unpackedSize != -1 && maxTotalRequestedSize <= _totalWriteSize)
+                if (_isEndOfStream || _unpackedSize != -1 && maxTotalRequestedSize <= _totalWriteSize)
                 {
                     break;
                 }
             }
-
-            //Thread.Sleep(1);
         }
 
         count = (int)Math.Min(count, _unpackedSize - _totalReadSize);

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
@@ -1158,6 +1158,7 @@ public sealed partial class SharpSevenZipExtractor
                 CheckedExecute(
                     _archive!.Extract(indexes, (uint)indexes.Length, 0, aec),
                     SharpSevenZipExtractionFailedException.DEFAULT_MESSAGE, aec);
+                (stream as ExtractStream)?.SignalEndOfStream();
             }
             finally
             {


### PR DESCRIPTION
There is a bug in the library currently that causes `Read` calls to hang when using `OpenFileStream` on a given archive instance. In these cases, the end of stream is reached before the file is fully expanded (presumably, due to having trailing zeroes). To fix the bug, `ExtractStream` now supports an explicit signal for end of stream handling, which is called in `ExtractFile` if applicable. 