### PR TITLE
Fix: do not dispose wrapped `Stream` instances for compress

### DIFF
--- a/SharpSevenZip/SharpSevenZip/ArchiveUpdateCallback.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveUpdateCallback.cs
@@ -650,7 +650,7 @@ internal sealed partial class ArchiveUpdateCallback : CallbackBase, IArchiveUpda
             }
             else
             {
-                _fileStream = new InStreamWrapper(_streams[index].Stream, true);
+                _fileStream = new InStreamWrapper(_streams[index].Stream, false);
                 inStream = _fileStream;
                 if (!EventsForGetStream(index))
                 {


### PR DESCRIPTION
This PR addresses a small bug where `Stream` instances passed to `SharpSevenZipCompressor.CompressStreamDictionary` would be disposed automatically. This is undesirable in cases where the user wants to reuse those instances for future processing, which is valid for certain use cases, including my own. Now, the disposal of those instances is left up to the user, while also still cleaning up wrapper resources. 