### PR TITLE
Feature: add support for more archive properties

### DIFF
--- a/SharpSevenZip/SharpSevenZip/Com.cs
+++ b/SharpSevenZip/SharpSevenZip/Com.cs
@@ -640,7 +640,8 @@ internal static class PropIdToName
                 {ItemPropId.HeadersSize, "Headers Size"},
                 {ItemPropId.Checksum, "Checksum"},
                 {ItemPropId.FreeSpace, "Free Space"},
-                {ItemPropId.ClusterSize, "Cluster Size"}
+                {ItemPropId.ClusterSize, "Cluster Size"},
+                {ItemPropId.VolumeName, "Volume Name"},
         };
     #endregion
 }

--- a/SharpSevenZip/SharpSevenZip/Com.cs
+++ b/SharpSevenZip/SharpSevenZip/Com.cs
@@ -642,6 +642,7 @@ internal static class PropIdToName
                 {ItemPropId.FreeSpace, "Free Space"},
                 {ItemPropId.ClusterSize, "Cluster Size"},
                 {ItemPropId.VolumeName, "Volume Name"},
+                {ItemPropId.TotalSize, "Total Size"},
         };
     #endregion
 }


### PR DESCRIPTION
This PR adds some extra dictionary entries for SharpSevenZip which refer to key properties of filesystem-based archive files. This allows users to access specific info about the filesystem that otherwise would be missing. 