### PR TITLE
Fix EventSynchronizationStrategy for FileCompressionStarted event

### DIFF
--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipCompressor.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipCompressor.cs
@@ -1013,7 +1013,7 @@ public sealed partial class SharpSevenZipCompressor
     /// <param name="e">The event arguments.</param>
     private void FileCompressionStartedEventProxy(object? sender, FileNameEventArgs e)
     {
-        OnEvent(FileCompressionStarted, e, false);
+        OnEvent(FileCompressionStarted, e, true);
     }
 
     /// <summary>


### PR DESCRIPTION
Update `FileCompressionStartedEventProxy` to pass `synchronous` as `true` instead of `false`

`synchronous` being set to `false` likely did not reflect the intended behavior, as the XML comment for `EventSynchronizationStrategy.Default` says:

> Events are called synchronously if user can do some action; that is, cancel the execution process for example.

However `FileNameEventArgs` - which are used by `FileCompressionStarted` - can very well be canceled.