### PR TITLE
Fix: exception & lost filename in archive name extraction

### DIFF
--- a/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
@@ -246,7 +246,11 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
                         if (_filesCount == 1)
                         {
                             var archName = Path.GetFileName(_extractor!.FileName);
-                            archName = archName![..archName!.LastIndexOf('.')];
+                            var dotIndex = archName!.LastIndexOf('.');
+                            if (dotIndex > 0)
+                            {
+                              archName = archName[..dotIndex];
+                            }
                             if (!archName.EndsWith(".tar",
                                                    StringComparison.OrdinalIgnoreCase))
                             {


### PR DESCRIPTION
Previously:

`"file.zip"` → `"file"`
`"archive"` → **exception** (`archName [..-1]`)
`".hidden"` → `""`

Now:

`"file.zip"` → `"file"`
`"archive"` → `"archive"`
`".hidden"` → `".hidden"`

If it weren't for the `.hidden` case, it could be simplified to

`var archName = Path.GetFileNameWithoutExtension(_extractor!.FileName);`

Though I'm unsure about the appending of `.tar` that follows?