### PR TITLE
Stragglers

### DIFF
--- a/SharpSevenZip/SharpSevenZip.Tests/LibraryManagerTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/LibraryManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using SharpSevenZip.Exceptions;
+using SharpSevenZip.Exceptions;
 
 namespace SharpSevenZip.Tests;
 
@@ -8,7 +8,7 @@ public class LibraryManagerTests : TestBase
     [Test]
     public void SetNonExistant7zDllLocationTest()
     {
-        Assert.Throws<SharpSevenZipLibraryException>(() => SharpSevenZipLibraryManager.SetLibraryPath("null"));
+        Assert.Throws<SharpSevenZipLibraryException>((Action)(() => SharpSevenZipLibraryManager.SetLibraryPath("null")));
     }
 
     [Test]
@@ -19,7 +19,7 @@ public class LibraryManagerTests : TestBase
         // Exercising more code paths...
         features = SharpSevenZipLibraryManager.CurrentLibraryFeatures;
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(features.HasFlag(LibraryFeature.ExtractAll), Is.True);
             Assert.That(features.HasFlag(LibraryFeature.CompressAll), Is.True);

--- a/SharpSevenZip/SharpSevenZip.Tests/MiscellaneousTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/MiscellaneousTests.cs
@@ -1,4 +1,4 @@
-﻿using SharpSevenZip.Lzma;
+using SharpSevenZip.Lzma;
 
 namespace SharpSevenZip.Tests;
 
@@ -38,7 +38,7 @@ public class MiscellaneousTests : TestBase
 
         using (var extractor = new SharpSevenZipExtractor(sfxFile))
         {
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)delegate
             {
                 Assert.That(extractor.FilesCount, Is.EqualTo(1));
                 Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("zip.zip"));
@@ -99,7 +99,7 @@ public class MiscellaneousTests : TestBase
 
         using var extractor = new SharpSevenZipExtractor(newZip);
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("zip.txt"));

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZip.Tests.csproj
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZip.Tests.csproj
@@ -11,18 +11,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="PolySharp" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipCompressorAsynchronousTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipCompressorAsynchronousTests.cs
@@ -1,4 +1,4 @@
-﻿using SharpSevenZip.Exceptions;
+using SharpSevenZip.Exceptions;
 
 namespace SharpSevenZip.Tests;
 
@@ -38,7 +38,7 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
 
         var numberOfTestDataFiles = Directory.GetFiles("TestData").Length;
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(filesFoundInvoked, Is.EqualTo(1));
             Assert.That(fileCompressionStartedInvoked, Is.EqualTo(numberOfTestDataFiles));
@@ -76,7 +76,7 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(2));
             Assert.That(extractor.ArchiveFileNames, Does.Contain("zip.zip"));
@@ -143,7 +143,7 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("tartar"));
@@ -175,14 +175,14 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(2));
             Assert.That(extractor.ArchiveFileNames, Does.Contain("zip.zip"));
             Assert.That(extractor.ArchiveFileNames, Does.Contain("tar.tar"));
         });
 
-        Assert.Throws<ExtractionFailedException>(() => extractor.ExtractArchive(OutputDirectory));
+        Assert.Throws<ExtractionFailedException>((Action)(() => extractor.ExtractArchive(OutputDirectory)));
     }
 
     [Test]
@@ -194,7 +194,7 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(2));
             Assert.That(extractor.ArchiveFileNames, Does.Contain("zip.zip"));
@@ -211,7 +211,7 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(Directory.GetFiles("TestData"), Has.Length.EqualTo(extractor.FilesCount));
             Assert.That(extractor.ArchiveFileNames, Does.Contain("zip.zip"));
@@ -228,13 +228,13 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile, "insecure");
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(2));
             Assert.That(extractor.ArchiveFileNames, Does.Contain("zip.zip"));
             Assert.That(extractor.ArchiveFileNames, Does.Contain("tar.tar"));
         });
 
-        Assert.Throws<ExtractionFailedException>(() => extractor.ExtractArchive(OutputDirectory));
+        Assert.Throws<ExtractionFailedException>((Action)(() => extractor.ExtractArchive(OutputDirectory)));
     }
 }

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipCompressorCustomParameterTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipCompressorCustomParameterTests.cs
@@ -1,4 +1,4 @@
-﻿using SharpSevenZip.Exceptions;
+using SharpSevenZip.Exceptions;
 
 namespace SharpSevenZip.Tests;
 
@@ -19,10 +19,10 @@ public class SharpSevenZipCompressorCustomParameterTests : TestBase
 
         // Check parameters for PPMd compression.
         compressor.CustomParameters.Add("mem", "25");
-        Assert.Throws<CompressionFailedException>(() => compressor.CompressFiles(TemporaryFile, @"TestData/zip.zip"));
+        Assert.Throws<CompressionFailedException>((Action)(() => compressor.CompressFiles(TemporaryFile, @"TestData/zip.zip")));
         compressor.CustomParameters.Remove("mem");
         compressor.CustomParameters.Add("o", "10");
-        Assert.Throws<CompressionFailedException>(() => compressor.CompressFiles(TemporaryFile, @"TestData/zip.zip"));
+        Assert.Throws<CompressionFailedException>((Action)(() => compressor.CompressFiles(TemporaryFile, @"TestData/zip.zip")));
         compressor.CustomParameters.Remove("o");
     }
 
@@ -35,11 +35,11 @@ public class SharpSevenZipCompressorCustomParameterTests : TestBase
         };
 
         compressor.CustomParameters.Add("x", "3");
-        Assert.Throws<CompressionFailedException>(() => compressor.CompressFiles(TemporaryFile, @"TestData/zip.zip"));
+        Assert.Throws<CompressionFailedException>((Action)(() => compressor.CompressFiles(TemporaryFile, @"TestData/zip.zip")));
         compressor.CustomParameters.Remove("x");
 
         compressor.CustomParameters.Add("em", "AES128");
-        Assert.Throws<CompressionFailedException>(() => compressor.CompressFiles(TemporaryFile, @"TestData/zip.zip"));
+        Assert.Throws<CompressionFailedException>((Action)(() => compressor.CompressFiles(TemporaryFile, @"TestData/zip.zip")));
     }
 
     [Test]

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipCompressorTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipCompressorTests.cs
@@ -1,4 +1,4 @@
-﻿using SharpSevenZip.Exceptions;
+using SharpSevenZip.Exceptions;
 
 namespace SharpSevenZip.Tests;
 
@@ -35,7 +35,7 @@ public class SharpSevenZipCompressorTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileNames[0].StartsWith("TestData_LongerDirectoryName", StringComparison.OrdinalIgnoreCase), Is.True);
@@ -47,8 +47,8 @@ public class SharpSevenZipCompressorTests : TestBase
     {
         var compressor = new SharpSevenZipCompressor();
 
-        Assert.Throws<ArgumentException>(() => compressor.CompressDirectory("nonexistent", TemporaryFile));
-        Assert.Throws<ArgumentException>(() => compressor.CompressDirectory("", TemporaryFile));
+        Assert.Throws<ArgumentException>((Action)(() => compressor.CompressDirectory("nonexistent", TemporaryFile)));
+        Assert.Throws<ArgumentException>((Action)(() => compressor.CompressDirectory("", TemporaryFile)));
     }
 
     [Test]
@@ -63,7 +63,7 @@ public class SharpSevenZipCompressorTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("emptyfile.txt"));
@@ -161,7 +161,7 @@ public class SharpSevenZipCompressorTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile, "password");
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("changed.zap"));
@@ -180,7 +180,7 @@ public class SharpSevenZipCompressorTests : TestBase
 
         var modificationList = new Dictionary<int, string?> { { 0, "" } };
 
-        Assert.Throws<SharpSevenZipArchiveException>(() => compressor.ModifyArchive(TemporaryFile, modificationList));
+        Assert.Throws<SharpSevenZipArchiveException>((Action)(() => compressor.ModifyArchive(TemporaryFile, modificationList)));
     }
 
     [Test]
@@ -203,7 +203,7 @@ public class SharpSevenZipCompressorTests : TestBase
             extractor.ExtractArchive(OutputDirectory);
         }
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(File.Exists(Path.Combine(OutputDirectory, "renamed.7z")), Is.True);
             Assert.That(File.Exists(Path.Combine(OutputDirectory, "7z_LZMA2.7z")), Is.False);
@@ -245,7 +245,7 @@ public class SharpSevenZipCompressorTests : TestBase
 
         compressor.CompressFiles(TemporaryFile, @"TestData/7z_LZMA2.7z");
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(Directory.GetFiles(OutputDirectory), Has.Length.EqualTo(3));
             Assert.That(File.Exists($"{TemporaryFile}.003"), Is.True);
@@ -265,7 +265,7 @@ public class SharpSevenZipCompressorTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("zip.zip"));
@@ -290,7 +290,7 @@ public class SharpSevenZipCompressorTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileData[0].Size, Is.EqualTo(new FileInfo(@"TestData/zip.zip").Length));
@@ -312,7 +312,7 @@ public class SharpSevenZipCompressorTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("zip.zip"));
@@ -342,7 +342,7 @@ public class SharpSevenZipCompressorTests : TestBase
         Assert.That(File.Exists(TemporaryFile), Is.True);
         {
             using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)delegate
             {
                 Assert.That(extractor.FilesCount, Is.EqualTo(1));
                 Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("zip.zip"));
@@ -367,7 +367,7 @@ public class SharpSevenZipCompressorTests : TestBase
         compressor.CompressStreamDictionary(fileDict, TemporaryFile);
         {
             using var extractor = new SharpSevenZipExtractor(TemporaryFile);
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)delegate
             {
                 Assert.That(extractor.FilesCount, Is.EqualTo(2));
                 Assert.That(extractor.ArchiveFileNames[1], Is.EqualTo("zip2.zip"));
@@ -401,7 +401,7 @@ public class SharpSevenZipCompressorTests : TestBase
         t1.Join();
         t2.Join();
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(File.Exists(tempFile1), Is.True);
             Assert.That(File.Exists(tempFile2), Is.True);
@@ -461,7 +461,7 @@ public class SharpSevenZipCompressorTests : TestBase
         }
 
         using var extractor = new SharpSevenZipExtractor(TemporaryFile, "password");
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractor.FilesCount, Is.EqualTo(1));
             Assert.That(extractor.ArchiveFileNames[0], Is.EqualTo("zip.zip"));

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorAsynchronousTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorAsynchronousTests.cs
@@ -1,4 +1,4 @@
-﻿namespace SharpSevenZip.Tests;
+namespace SharpSevenZip.Tests;
 
 [TestFixture]
 public class SharpSevenZipExtractorAsynchronousTests : TestBase
@@ -35,7 +35,7 @@ public class SharpSevenZipExtractorAsynchronousTests : TestBase
             //timeToWait -= 25;
         }
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractingInvoked, Is.EqualTo(3));
             Assert.That(extractionFinishedInvoked, Is.EqualTo(1));
@@ -90,7 +90,7 @@ public class SharpSevenZipExtractorAsynchronousTests : TestBase
             Thread.Sleep(25);
         }
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractionFinishedInvoked, Is.True);
             Assert.That(File.ReadAllText(TemporaryFile), Is.EqualTo("file1"));
@@ -125,7 +125,7 @@ public class SharpSevenZipExtractorAsynchronousTests : TestBase
             Thread.Sleep(25);
         }
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(extractionFinishedInvoked, Is.True);
             Assert.That(Directory.GetFiles(OutputDirectory), Has.Length.EqualTo(2));
@@ -152,7 +152,7 @@ public class SharpSevenZipExtractorAsynchronousTests : TestBase
             await extractor.ExtractFileAsync(0, fileStream);
         }
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(Directory.GetFiles(OutputDirectory), Has.Length.EqualTo(1));
             Assert.That(File.ReadAllText(TemporaryFile), Is.EqualTo("file1"));
@@ -168,7 +168,7 @@ public class SharpSevenZipExtractorAsynchronousTests : TestBase
             await extractor.ExtractFileAsync("file1.txt", fileStream);
         }
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(Directory.GetFiles(OutputDirectory), Has.Length.EqualTo(1));
             Assert.That(File.ReadAllText(TemporaryFile), Is.EqualTo("file1"));

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
@@ -1,4 +1,4 @@
-﻿namespace SharpSevenZip.Tests;
+namespace SharpSevenZip.Tests;
 
 [TestFixture]
 public class SharpSevenZipExtractorTests : TestBase
@@ -59,7 +59,7 @@ public class SharpSevenZipExtractorTests : TestBase
             extractor.ExtractArchive(OutputDirectory);
         }
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(Directory.GetFiles(OutputDirectory), Has.Length.EqualTo(1));
             Assert.That(File.ReadAllText(Directory.GetFiles(OutputDirectory)[0]), Does.StartWith("Lorem ipsum dolor sit amet"));
@@ -154,7 +154,7 @@ public class SharpSevenZipExtractorTests : TestBase
     {
         using (var tmp = new SharpSevenZipExtractor(@"TestData/multivolume.part0001.rar"))
         {
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)delegate
             {
                 Assert.That(tmp.ArchiveProperties.Any(x => x.Name.Equals("IsVolume") && x.Value != null && x.Value.Equals(true)), Is.True);
                 Assert.That(tmp.ArchiveProperties.Any(x => x.Name.Equals("VolumeIndex") && x.Value != null && Convert.ToInt32(x.Value) == 0), Is.True);
@@ -163,7 +163,7 @@ public class SharpSevenZipExtractorTests : TestBase
 
         using (var tmp = new SharpSevenZipExtractor(@"TestData/multivolume.part0002.rar"))
         {
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)delegate
             {
                 Assert.That(tmp.ArchiveProperties.Any(x => x.Name.Equals("IsVolume") && x.Value != null && x.Value.Equals(true)), Is.True);
                 Assert.That(tmp.ArchiveProperties.Any(x => x.Name.Equals("VolumeIndex") && x.Value != null && Convert.ToInt32(x.Value) == 0), Is.False);
@@ -194,7 +194,7 @@ public class SharpSevenZipExtractorTests : TestBase
         t1.Join();
         t2.Join();
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(Directory.Exists(destination1), Is.True);
             Assert.That(Directory.Exists(destination2), Is.True);
@@ -207,7 +207,7 @@ public class SharpSevenZipExtractorTests : TestBase
     public void ExtractArchiveWithLongPath()
     {
         using var extractor = new SharpSevenZipExtractor(@"TestData/long_path.7z");
-        Assert.Throws<PathTooLongException>(() => extractor.ExtractArchive(OutputDirectory));
+        Assert.Throws<PathTooLongException>((Action)(() => extractor.ExtractArchive(OutputDirectory)));
     }
 
     [Test]
@@ -217,7 +217,7 @@ public class SharpSevenZipExtractorTests : TestBase
         var fileNames = extractor.ArchiveFileNames;
         Assert.That(fileNames, Has.Count.EqualTo(3));
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(fileNames[0], Is.EqualTo("file1.txt"));
             Assert.That(fileNames[1], Is.EqualTo("file2.txt"));
@@ -232,7 +232,7 @@ public class SharpSevenZipExtractorTests : TestBase
         var fileData = extractor.ArchiveFileData;
         Assert.That(fileData, Has.Count.EqualTo(3));
 
-        Assert.Multiple(() =>
+        Assert.Multiple((Action)delegate
         {
             Assert.That(fileData[0].FileName, Is.EqualTo("file1.txt"));
             Assert.That(fileData[0].Encrypted, Is.False);

--- a/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
@@ -111,7 +111,7 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
         _directory = directory;
         _actualIndexes = actualIndexes;
         _directoryStructure = directoryStructure;
-        if (!directory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.CurrentCulture))
+        if (_directory!.Length == 0 || _directory[_directory.Length - 1] != Path.DirectorySeparatorChar)
         {
             _directory += Path.DirectorySeparatorChar;
         }
@@ -249,7 +249,7 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
                             var dotIndex = archName!.LastIndexOf('.');
                             if (dotIndex > 0)
                             {
-                              archName = archName[..dotIndex];
+                                archName = archName[..dotIndex];
                             }
                             if (!archName.EndsWith(".tar",
                                                    StringComparison.OrdinalIgnoreCase))
@@ -556,11 +556,7 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
                 {
                     continue;
                 }
-                if (string.IsNullOrEmpty(splitFileName[i]))
-                {
-                    continue;
-                }
-                while (splitFileName[i].IndexOf(chr) > -1)
+                if (!string.IsNullOrEmpty(splitFileName[i]))
                 {
                     splitFileName[i] = splitFileName[i].Replace(chr, '_');
                 }

--- a/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
@@ -277,7 +277,10 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
                         }
 
                         // Zip Slip guard: ensure the resolved path stays inside the target directory.
-                        var fullTarget = Path.GetFullPath(_directory!);
+                        // fullTarget MUST end with a separator so "C:\output" doesn't match "C:\outputevil\..."
+                        var fullTarget = Path.GetFullPath(_directory!).TrimEnd(
+                            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                            + Path.DirectorySeparatorChar;
                         var fullEntry = Path.GetFullPath(fileName);
                         if (!fullEntry.StartsWith(fullTarget, StringComparison.OrdinalIgnoreCase))
                         {
@@ -538,6 +541,11 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
     /// <returns></returns>
     private static string RemoveIllegalCharacters(string str, bool isDirectory = false)
     {
+        // Normalise both kinds of path separator before splitting so that
+        // Unix-style '/' paths from Zip/Tar archives are handled correctly
+        // on Windows (where '/' is otherwise an invalid filename character).
+        str = str.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
         var splitFileName = new List<string>(str.Split(Path.DirectorySeparatorChar));
 
         foreach (var chr in Path.GetInvalidFileNameChars())

--- a/SharpSevenZip/SharpSevenZip/ArchiveOpenCallback.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveOpenCallback.cs
@@ -31,12 +31,13 @@ internal sealed partial class ArchiveOpenCallback : CallbackBase, IArchiveOpenCa
     {
         if (!string.IsNullOrEmpty(fileName))
         {
-            _fileInfo = new FileInfo(fileName);
-            _volumeFileNames.Add(fileName);
-            if (fileName.EndsWith("001", StringComparison.Ordinal))
+            var name = fileName!;
+            _fileInfo = new FileInfo(name);
+            _volumeFileNames.Add(name);
+            if (name.EndsWith("001", StringComparison.Ordinal))
             {
                 int index = 2;
-                var baseName = fileName[..^3];
+                var baseName = name[..^3];
                 var volName = baseName + index.ToString("D3", System.Globalization.CultureInfo.InvariantCulture);
                 while (File.Exists(volName))
                 {

--- a/SharpSevenZip/SharpSevenZip/Com.cs
+++ b/SharpSevenZip/SharpSevenZip/Com.cs
@@ -132,28 +132,35 @@ internal struct PropVariant
                         return DateTime.MinValue;
                     }
                 default:
-                    var propHandle = GCHandle.Alloc(this, GCHandleType.Pinned);
-
-                    try
+#if NET5_0_OR_GREATER
+                    if (OperatingSystem.IsWindows())
+#else
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+#endif
                     {
-                        return System.Runtime.InteropServices.Marshal.GetObjectForNativeVariant(propHandle.AddrOfPinnedObject());
-                    }
-                    catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
-                    {
-                        return VarType switch
+                        var propHandle = GCHandle.Alloc(this, GCHandleType.Pinned);
+                        try
                         {
-                            VarEnum.VT_UI8 => UInt64Value,
-                            VarEnum.VT_UI4 => UInt32Value,
-                            VarEnum.VT_I8 => Int64Value,
-                            VarEnum.VT_I4 => Int32Value,
-                            VarEnum.VT_BOOL => Int32Value != 0,
-                            _ => 0,
-                        };
+                            return System.Runtime.InteropServices.Marshal.GetObjectForNativeVariant(propHandle.AddrOfPinnedObject());
+                        }
+                        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
+                        {
+                            // fall through to platform-neutral conversion below
+                        }
+                        finally
+                        {
+                            propHandle.Free();
+                        }
                     }
-                    finally
+                    return VarType switch
                     {
-                        propHandle.Free();
-                    }
+                        VarEnum.VT_UI8 => UInt64Value,
+                        VarEnum.VT_UI4 => UInt32Value,
+                        VarEnum.VT_I8 => Int64Value,
+                        VarEnum.VT_I4 => Int32Value,
+                        VarEnum.VT_BOOL => Int32Value != 0,
+                        _ => 0,
+                    };
             }
         }
     }

--- a/SharpSevenZip/SharpSevenZip/Directory.Build.targets
+++ b/SharpSevenZip/SharpSevenZip/Directory.Build.targets
@@ -1,6 +1,0 @@
-<Project>
-  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
-  <Target Name="CustomAfterBuildTarget" AfterTargets="Build">
-      <Message Text="Hello from CustomAfterBuildTarget" Importance="high" />
-  </Target>
-</Project>

--- a/SharpSevenZip/SharpSevenZip/Exceptions/CompressionFailedException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/CompressionFailedException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class CompressionFailedException : SharpSevenZipException
     public CompressionFailedException(string message, Exception inner)
         : base(DEFAULT_MESSAGE, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the CompressionFailedException class
     /// </summary>
@@ -42,4 +45,5 @@ public class CompressionFailedException : SharpSevenZipException
     protected CompressionFailedException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/ExtractionFailedException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/ExtractionFailedException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class ExtractionFailedException : SharpSevenZipException
     public ExtractionFailedException(string message, Exception inner)
         : base(DEFAULT_MESSAGE, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the ExtractionFailedException class
     /// </summary>
@@ -42,4 +45,5 @@ public class ExtractionFailedException : SharpSevenZipException
     protected ExtractionFailedException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/LzmaException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/LzmaException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class LzmaException : SharpSevenZipException
     public LzmaException(string message, Exception inner)
         : base(DEFAULT_MESSAGE, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the LzmaException class
     /// </summary>
@@ -42,4 +45,5 @@ public class LzmaException : SharpSevenZipException
     protected LzmaException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipArchiveException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipArchiveException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -37,6 +39,7 @@ public class SharpSevenZipArchiveException : SharpSevenZipException
     public SharpSevenZipArchiveException(string message, Exception inner)
         : base(DefaultMessage, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the SharpSevenZipArchiveException class
     /// </summary>
@@ -45,4 +48,5 @@ public class SharpSevenZipArchiveException : SharpSevenZipException
     protected SharpSevenZipArchiveException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipCompressionFailedException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipCompressionFailedException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class SharpSevenZipCompressionFailedException : SharpSevenZipException
     public SharpSevenZipCompressionFailedException(string message, Exception inner)
         : base(DEFAULT_MESSAGE, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the SharpSevenZipCompressionFailedException class
     /// </summary>
@@ -42,4 +45,5 @@ public class SharpSevenZipCompressionFailedException : SharpSevenZipException
     protected SharpSevenZipCompressionFailedException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipConfigurationException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipConfigurationException.cs
@@ -1,4 +1,6 @@
+#if !NET8_0_OR_GREATER
 using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class SharpSevenZipConfigurationException : SharpSevenZipException
     public SharpSevenZipConfigurationException(string message, Exception inner)
         : base(DEFAULT_MESSAGE, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the SharpSevenZipExtractionFailedException class
     /// </summary>
@@ -42,4 +45,5 @@ public class SharpSevenZipConfigurationException : SharpSevenZipException
     protected SharpSevenZipConfigurationException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -54,6 +56,7 @@ public class SharpSevenZipException : Exception
     public SharpSevenZipException(string defaultMessage, Exception inner)
         : base(defaultMessage, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the SharpSevenZipException class
     /// </summary>
@@ -62,4 +65,5 @@ public class SharpSevenZipException : Exception
     protected SharpSevenZipException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipExtractionFailedException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipExtractionFailedException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class SharpSevenZipExtractionFailedException : SharpSevenZipException
     public SharpSevenZipExtractionFailedException(string message, Exception inner)
         : base(DEFAULT_MESSAGE, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the SharpSevenZipExtractionFailedException class
     /// </summary>
@@ -42,4 +45,5 @@ public class SharpSevenZipExtractionFailedException : SharpSevenZipException
     protected SharpSevenZipExtractionFailedException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipInvalidFileNamesException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipInvalidFileNamesException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class SharpSevenZipInvalidFileNamesException : SharpSevenZipException
     public SharpSevenZipInvalidFileNamesException(string message, Exception inner)
         : base(DEFAULT_MESSAGE, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the SharpSevenZipInvalidFileNamesException class
     /// </summary>
@@ -42,4 +45,5 @@ public class SharpSevenZipInvalidFileNamesException : SharpSevenZipException
     protected SharpSevenZipInvalidFileNamesException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipLibraryException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipLibraryException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class SharpSevenZipLibraryException : SharpSevenZipException
     public SharpSevenZipLibraryException(string message, Exception inner)
         : base(DEFAULT_MESSAGE, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the SharpSevenZipLibraryException class
     /// </summary>
@@ -42,4 +45,5 @@ public class SharpSevenZipLibraryException : SharpSevenZipException
     protected SharpSevenZipLibraryException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipSfxValidationException.cs
+++ b/SharpSevenZip/SharpSevenZip/Exceptions/SharpSevenZipSfxValidationException.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 
 namespace SharpSevenZip.Exceptions;
 
@@ -34,6 +36,7 @@ public class SharpSevenZipSfxValidationException : SharpSevenZipException
     public SharpSevenZipSfxValidationException(string message, Exception inner)
         : base(DefaultMessage, message, inner) { }
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Initializes a new instance of the SharpSevenZipSfxValidationException class
     /// </summary>
@@ -42,4 +45,5 @@ public class SharpSevenZipSfxValidationException : SharpSevenZipException
     protected SharpSevenZipSfxValidationException(
         SerializationInfo info, StreamingContext context)
         : base(info, context) { }
+#endif
 }

--- a/SharpSevenZip/SharpSevenZip/FileChecker.cs
+++ b/SharpSevenZip/SharpSevenZip/FileChecker.cs
@@ -162,7 +162,7 @@ internal static class FileChecker
         {
             stream.Seek(-1024, SeekOrigin.End);
             var buf = new byte[1024];
-            stream.Read(buf, 0, 1024);
+            ReadFully(stream, buf, 0, buf.Length);
 
             if (Array.TrueForAll(buf, b => b == 0))
             {

--- a/SharpSevenZip/SharpSevenZip/FileChecker.cs
+++ b/SharpSevenZip/SharpSevenZip/FileChecker.cs
@@ -115,11 +115,16 @@ internal static class FileChecker
 
         #region SpecialDetect
 
-        try
+        if (SpecialDetect(stream, 257, InArchiveFormat.Tar))
         {
-            SpecialDetect(stream, 257, InArchiveFormat.Tar);
+            return InArchiveFormat.Tar;
         }
-        catch (ArgumentException) { }
+
+        // UDF BEA01 at 0x8000; check before ISO so pure-UDF (no CD001 bridge) is detected correctly
+        if (SpecialDetect(stream, 0x8000, InArchiveFormat.Udf))
+        {
+            return InArchiveFormat.Udf;
+        }
 
         if (SpecialDetect(stream, 0x8001, InArchiveFormat.Iso))
         {

--- a/SharpSevenZip/SharpSevenZip/FileChecker.cs
+++ b/SharpSevenZip/SharpSevenZip/FileChecker.cs
@@ -9,36 +9,44 @@ internal static class FileChecker
     private const int SIGNATURE_SIZE = 21;
     private const int SFX_SCAN_LENGTH = 256 * 1024;
 
+    /// <summary>
+    /// Reads exactly <paramref name="count"/> bytes from <paramref name="stream"/> into
+    /// <paramref name="buffer"/> starting at <paramref name="offset"/>.
+    /// </summary>
+    private static void ReadFully(Stream stream, byte[] buffer, int offset, int count)
+    {
+#if NET8_0_OR_GREATER
+        stream.ReadExactly(buffer, offset, count);
+#else
+        while (count > 0)
+        {
+            var read = stream.Read(buffer, offset, count);
+            if (read == 0)
+                throw new EndOfStreamException();
+            offset += read;
+            count -= read;
+        }
+#endif
+    }
+
     private static bool SpecialDetect(Stream stream, int offset, InArchiveFormat expectedFormat)
     {
-        if (stream.Length > offset + SIGNATURE_SIZE)
+        if (stream.Length <= offset + SIGNATURE_SIZE)
+            return false;
+
+        var signature = new byte[SIGNATURE_SIZE];
+        stream.Seek(offset, SeekOrigin.Begin);
+        ReadFully(stream, signature, 0, SIGNATURE_SIZE);
+
+        var actualSignature = BitConverter.ToString(signature);
+
+        foreach (var expectedSignature in Formats.InSignatureFormats)
         {
-            var signature = new byte[SIGNATURE_SIZE];
-            var bytesRequired = SIGNATURE_SIZE;
-            var index = 0;
-            stream.Seek(offset, SeekOrigin.Begin);
+            if (expectedSignature.Value != expectedFormat)
+                continue;
 
-            while (bytesRequired > 0)
-            {
-                var bytesRead = stream.Read(signature, index, bytesRequired);
-                bytesRequired -= bytesRead;
-                index += bytesRead;
-            }
-
-            var actualSignature = BitConverter.ToString(signature);
-
-            foreach (var expectedSignature in Formats.InSignatureFormats)
-            {
-                if (expectedSignature.Value != expectedFormat)
-                {
-                    continue;
-                }
-
-                if (actualSignature.AsSpan().StartsWith(expectedSignature.Key.AsSpan(), StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
+            if (actualSignature.AsSpan().StartsWith(expectedSignature.Key.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                return true;
         }
 
         return false;
@@ -56,9 +64,9 @@ internal static class FileChecker
         offset = 0;
         isExecutable = false;
 
-        if (!stream.CanRead)
+        if (!stream.CanRead || !stream.CanSeek)
         {
-            throw new ArgumentException("The stream must be readable.");
+            throw new ArgumentException("The stream must be readable and seekable.");
         }
 
         if (stream.Length < SIGNATURE_SIZE)
@@ -66,25 +74,13 @@ internal static class FileChecker
             throw new ArgumentException("The stream is invalid.");
         }
 
-        #region Get file signature
-
         var signature = new byte[SIGNATURE_SIZE];
-        var bytesRequired = SIGNATURE_SIZE;
-        var index = 0;
         stream.Seek(0, SeekOrigin.Begin);
-
-        while (bytesRequired > 0)
-        {
-            var bytesRead = stream.Read(signature, index, bytesRequired);
-            bytesRequired -= bytesRead;
-            index += bytesRead;
-        }
+        ReadFully(stream, signature, 0, SIGNATURE_SIZE);
 
         var actualSignature = BitConverter.ToString(signature);
 
-        #endregion
-
-        var suspectedFormat = InArchiveFormat.XZ; // any except PE and Cab
+        InArchiveFormat? suspectedFormat = null;
         isExecutable = false;
 
         foreach (var expectedSignature in Formats.InSignatureFormats)
@@ -110,12 +106,15 @@ internal static class FileChecker
         // Many Microsoft formats
         if (actualSignature.StartsWith("D0-CF-11-E0-A1-B1-1A-E1", StringComparison.OrdinalIgnoreCase))
         {
-            suspectedFormat = InArchiveFormat.Cab; // != InArchiveFormat.XZ
+            suspectedFormat = InArchiveFormat.Compound;
         }
 
         #region SpecialDetect
 
-        if (SpecialDetect(stream, 257, InArchiveFormat.Tar))
+        // PE/SFX and OLE2/Compound files must not be short-circuited as TAR even if "ustar"
+        // bytes appear at offset 257 inside their binary content. Only check for TAR when
+        // no other format has been suspected yet.
+        if (suspectedFormat == null && SpecialDetect(stream, 257, InArchiveFormat.Tar))
         {
             return InArchiveFormat.Tar;
         }
@@ -126,17 +125,9 @@ internal static class FileChecker
             return InArchiveFormat.Udf;
         }
 
-        if (SpecialDetect(stream, 0x8001, InArchiveFormat.Iso))
-        {
-            return InArchiveFormat.Iso;
-        }
-
-        if (SpecialDetect(stream, 0x8801, InArchiveFormat.Iso))
-        {
-            return InArchiveFormat.Iso;
-        }
-
-        if (SpecialDetect(stream, 0x9001, InArchiveFormat.Iso))
+        if (SpecialDetect(stream, 0x8001, InArchiveFormat.Iso) ||
+            SpecialDetect(stream, 0x8801, InArchiveFormat.Iso) ||
+            SpecialDetect(stream, 0x9001, InArchiveFormat.Iso))
         {
             return InArchiveFormat.Iso;
         }
@@ -157,7 +148,7 @@ internal static class FileChecker
         {
             return InArchiveFormat.Lp;
         }
-        
+
         // VDI: magic (k_Signature) is at offset 0x40
         // cf. https://github.com/ip7z/7zip/blob/main/CPP/7zip/Archive/VdiHandler.cpp#L287
         if (SpecialDetect(stream, 0x40, InArchiveFormat.Vdi))
@@ -167,19 +158,13 @@ internal static class FileChecker
 
         #region Last resort for tar - can mistake
 
-        if (stream.Length >= 1024)
+        if (suspectedFormat == null && stream.Length >= 1024)
         {
             stream.Seek(-1024, SeekOrigin.End);
             var buf = new byte[1024];
             stream.Read(buf, 0, 1024);
-            var isTar = true;
 
-            for (var i = 0; i < 1024; i++)
-            {
-                isTar = isTar && buf[i] == 0;
-            }
-
-            if (isTar)
+            if (Array.TrueForAll(buf, b => b == 0))
             {
                 return InArchiveFormat.Tar;
             }
@@ -191,26 +176,15 @@ internal static class FileChecker
 
         #region Check if it is an SFX archive or a file with an embedded archive.
 
-        if (suspectedFormat != InArchiveFormat.XZ)
+        if (suspectedFormat != null)
         {
-            #region Get first Min(stream.Length, SFX_SCAN_LENGTH) bytes
 
             var scanLength = Math.Min(stream.Length, SFX_SCAN_LENGTH);
             signature = new byte[scanLength];
-            bytesRequired = (int)scanLength;
-            index = 0;
             stream.Seek(0, SeekOrigin.Begin);
-
-            while (bytesRequired > 0)
-            {
-                var bytesRead = stream.Read(signature, index, bytesRequired);
-                bytesRequired -= bytesRead;
-                index += bytesRead;
-            }
+            ReadFully(stream, signature, 0, (int)scanLength);
 
             actualSignature = BitConverter.ToString(signature);
-
-            #endregion
 
             foreach (var format in new[]
             {

--- a/SharpSevenZip/SharpSevenZip/Formats.cs
+++ b/SharpSevenZip/SharpSevenZip/Formats.cs
@@ -303,6 +303,16 @@ public enum InArchiveFormat
     /// </summary>
     /// <remarks><a href="https://en.wikipedia.org/wiki/Base64">Wikipedia information</a></remarks>
     Base64,
+    /// <summary>
+    /// Android Verified Boot image format.
+    /// </summary>
+    /// <remarks><a href="https://source.android.com/docs/security/features/verifiedboot">Android documentation</a></remarks>
+    Avb,
+    /// <summary>
+    /// Linux Logical Volume Manager format.
+    /// </summary>
+    /// <remarks><a href="https://en.wikipedia.org/wiki/Logical_Volume_Manager_(Linux)">Wikipedia information</a></remarks>
+    Lvm,
 }
 
 /// <summary>
@@ -505,6 +515,9 @@ public static class Formats
                 {InArchiveFormat.Sparse,    new Guid("23170f69-40c1-278a-1000-000110C20000")},
                 {InArchiveFormat.Coff,      new Guid("23170f69-40c1-278a-1000-000110C60000")},
                 {InArchiveFormat.Base64,    new Guid("23170f69-40c1-278a-1000-000110C50000")},
+                {InArchiveFormat.Msi,       new Guid("23170f69-40c1-278a-1000-000110e50000")},
+                {InArchiveFormat.Avb,       new Guid("23170f69-40c1-278a-1000-000110C00000")},
+                {InArchiveFormat.Lvm,       new Guid("23170f69-40c1-278a-1000-000110BF0000")},
         };
 
     #endregion
@@ -628,6 +641,13 @@ public static class Formats
              // Ar/deb - same 7-zip handler (format 0xEC)
              {"ar",     InArchiveFormat.Deb },
              {"a",      InArchiveFormat.Deb },
+             // MSI uses the same 7-zip Compound handler (format 0xE5)
+             {"msi",    InArchiveFormat.Msi },
+             {"msp",    InArchiveFormat.Msi },
+             {"msm",    InArchiveFormat.Msi },
+             // Virtual machine disk images
+             {"avb",    InArchiveFormat.Avb },
+             {"lvm",    InArchiveFormat.Lvm },
     };
 
     #endregion
@@ -652,7 +672,7 @@ public static class Formats
             {"5D-00-00-40-00",                                                  InArchiveFormat.Lzma},
             {"2D-6C-68",                                                        InArchiveFormat.Lzh},
             //^ 2 byte offset
-            {"1F-9D-90",                                                        InArchiveFormat.Lzw},
+            {"1F-9D",                                                            InArchiveFormat.Lzw},
             {"60-EA",                                                           InArchiveFormat.Arj},
             {"42-5A-68",                                                        InArchiveFormat.BZip2},
             {"4D-53-43-46",                                                     InArchiveFormat.Cab},
@@ -663,18 +683,24 @@ public static class Formats
             //^ 0x8001, 0x8801 or 0x9001 byte offset
             {"ED-AB-EE-DB",                                                     InArchiveFormat.Rpm},
             {"4D-53-57-49-4D-00-00-00",                                         InArchiveFormat.Wim},
-            {"udf",                                                             InArchiveFormat.Udf},
-            {"mub",                                                             InArchiveFormat.Mub},
+            // UDF: Beginning Extended Area Descriptor (BEA01) at offset 0x8000
+            {"00-42-45-41-30-31-01-00",                                         InArchiveFormat.Udf},
+
             {"78-61-72-21",                                                     InArchiveFormat.Xar},
             //0x400 byte offset
             {"48-2B",                                                           InArchiveFormat.Hfs},
-            {"FD-37-7A-58-5A",                                                  InArchiveFormat.XZ},
+            {"FD-37-7A-58-5A-00",                                               InArchiveFormat.XZ},
             {"46-4C-56",                                                        InArchiveFormat.Flv},
             {"46-57-53",                                                        InArchiveFormat.Swf},
+            {"43-57-53",                                                        InArchiveFormat.Swfc},
+            {"5A-57-53",                                                        InArchiveFormat.Swfc},
             {"4D-5A",                                                           InArchiveFormat.PE},
             {"7F-45-4C-46",                                                     InArchiveFormat.Elf},
             {"78",                                                              InArchiveFormat.Dmg},
             {"63-6F-6E-65-63-74-69-78",                                         InArchiveFormat.Vhd},
+            // Mub (Mach-O fat binary): 7-byte sig avoids Java .class false positive (CA-FE-BA-BE alone)
+            {"CA-FE-BA-BE-00-00-00",                                            InArchiveFormat.Mub},
+            {"B9-FA-F1-0E",                                                     InArchiveFormat.Mub},
             {"45-46-49-20-50-41-52-54-00-00-01-00",                             InArchiveFormat.Gpt},
             {"28-B5-2F-FD",                                                     InArchiveFormat.Zstd},
             {"76-68-64-78-66-69-6C-65",                                         InArchiveFormat.Vhdx},

--- a/SharpSevenZip/SharpSevenZip/Formats.cs
+++ b/SharpSevenZip/SharpSevenZip/Formats.cs
@@ -313,6 +313,10 @@ public enum InArchiveFormat
     /// </summary>
     /// <remarks><a href="https://en.wikipedia.org/wiki/Logical_Volume_Manager_(Linux)">Wikipedia information</a></remarks>
     Lvm,
+    /// <summary>
+    /// Unknown or unrecognized format (sentinel/not-found value).
+    /// </summary>
+    None = -1,
 }
 
 /// <summary>
@@ -745,11 +749,15 @@ public static class Formats
         var rawExt = Path.GetExtension(fileName);
         string extension = rawExt.Length > 0 ? rawExt[1..] : "";
 
-        if (!InExtensionFormats.ContainsKey(extension) && reportErrors)
+        if (!InExtensionFormats.TryGetValue(extension, out var format))
         {
-            throw new ArgumentException("Extension \"" + extension + "\" is not a supported archive file name extension.");
+            if (reportErrors)
+            {
+                throw new ArgumentException($"Extension \"{extension}\" is not a supported archive file name extension.");
+            }
+            return InArchiveFormat.None;
         }
 
-        return InExtensionFormats[extension];
+        return format;
     }
 }

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZip.csproj
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZip.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="PolySharp" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -69,8 +69,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Buffers" Version="4.6.1" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZip.csproj
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZip.csproj
@@ -24,6 +24,7 @@
     <PackageProjectUrl>https://github.com/JeremyAnsel/SharpSevenZip</PackageProjectUrl>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <NoWarn>$(NoWarn);CS3016</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
@@ -33,7 +33,7 @@ public sealed partial class SharpSevenZipExtractor
     private bool? _isSolid;
     private bool _opened;
     private bool _disposed;
-    private InArchiveFormat _format = (InArchiveFormat)(-1);
+    private InArchiveFormat _format = InArchiveFormat.None;
     private ReadOnlyCollection<ArchiveFileInfo>? _archiveFileInfoCollection;
     private ReadOnlyCollection<ArchiveProperty>? _archiveProperties;
     private ReadOnlyCollection<string>? _volumeFileNames;
@@ -55,7 +55,7 @@ public sealed partial class SharpSevenZipExtractor
         _fileName = archiveFullName;
         var isExecutable = false;
 
-        if ((int)_format == -1)
+        if (_format == InArchiveFormat.None)
         {
             _format = FileChecker.CheckSignature(archiveFullName, out _offset, out isExecutable);
         }
@@ -103,7 +103,7 @@ public sealed partial class SharpSevenZipExtractor
         ValidateStream(stream);
         var isExecutable = false;
 
-        if ((int)_format == -1)
+        if (_format == InArchiveFormat.None)
         {
             _format = FileChecker.CheckSignature(stream, out _offset, out isExecutable);
         }
@@ -165,7 +165,7 @@ public sealed partial class SharpSevenZipExtractor
     /// <param name="leaveOpen">Leaves the base stream open.</param>
     /// <remarks>The archive format is guessed by the signature.</remarks>
     public SharpSevenZipExtractor(Stream archiveStream, bool leaveOpen)
-        : this(archiveStream, leaveOpen, (InArchiveFormat)(-1))
+        : this(archiveStream, leaveOpen, InArchiveFormat.None)
     {
     }
 
@@ -252,7 +252,7 @@ public sealed partial class SharpSevenZipExtractor
     /// <param name="leaveOpen">Leaves the base stream open.</param>
     /// <remarks>The archive format is guessed by the signature.</remarks>
     public SharpSevenZipExtractor(Stream archiveStream, string password, bool leaveOpen)
-        : this(archiveStream, password, leaveOpen, (InArchiveFormat)(-1))
+        : this(archiveStream, password, leaveOpen, InArchiveFormat.None)
     {
     }
 

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipSfx.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipSfx.cs
@@ -43,8 +43,11 @@ public enum SfxModule
 /// </summary>
 public enum SfxTarget
 {
-    Auto, // use Environment.Is64BitProcess
+    /// <summary>Automatically choose the platform based on <see cref="Environment.Is64BitProcess"/>.</summary>
+    Auto,
+    /// <summary>Target 32-bit (x86) platform.</summary>
     X86,
+    /// <summary>Target 64-bit (x64) platform.</summary>
     X64
 }
 /// <summary>
@@ -52,6 +55,7 @@ public enum SfxTarget
 /// </summary>
 public class SharpSevenZipSfx
 {
+    /// <summary>Gets or sets the target platform for the self-extracting archive.</summary>
     public static SfxTarget TargetPlatform { get; set; } = SfxTarget.Auto;
     private static Dictionary<SfxModule, List<string>> SfxSupportedModuleNames
     {

--- a/SharpSevenZip/SharpSevenZip/StreamWithAttributes.cs
+++ b/SharpSevenZip/SharpSevenZip/StreamWithAttributes.cs
@@ -1,3 +1,10 @@
 ﻿namespace SharpSevenZip;
 
+/// <summary>
+/// Associates a <see cref="System.IO.Stream"/> with optional file-time attributes for use in archive compression.
+/// </summary>
+/// <param name="Stream">The stream containing the file data to compress.</param>
+/// <param name="CreationTime">The creation time to store in the archive, or <c>null</c> to omit.</param>
+/// <param name="LastWriteTime">The last-write time to store in the archive, or <c>null</c> to omit.</param>
+/// <param name="LastAccessTime">The last-access time to store in the archive, or <c>null</c> to omit.</param>
 public record StreamWithAttributes(Stream Stream, DateTime? CreationTime = null, DateTime? LastWriteTime = null, DateTime? LastAccessTime = null);

--- a/SharpSevenZip/SharpSevenZipBenchmarks/Benchmarks.cs
+++ b/SharpSevenZip/SharpSevenZipBenchmarks/Benchmarks.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Jobs;
 using SharpCompress.Archives;
@@ -111,7 +111,7 @@ public class Benchmarks
 
         for (int i = 0; i < 10; i++)
         {
-            using IArchive zip = ArchiveFactory.Open("empty.zip");
+            using IArchive zip = ArchiveFactory.OpenArchive("empty.zip");
 
             foreach (var entry in zip.Entries)
             {
@@ -186,7 +186,7 @@ public class Benchmarks
 
         for (int i = 0; i < 10; i++)
         {
-            using IArchive zip = ArchiveFactory.Open(Test1Archive);
+            using IArchive zip = ArchiveFactory.OpenArchive(Test1Archive);
 
             foreach (var entry in zip.Entries)
             {
@@ -206,7 +206,7 @@ public class Benchmarks
 
         for (int i = 0; i < 10; i++)
         {
-            using IArchive zip = ArchiveFactory.Open(Test1Archive);
+            using IArchive zip = ArchiveFactory.OpenArchive(Test1Archive);
 
             foreach (var entry in zip.Entries)
             {

--- a/SharpSevenZip/SharpSevenZipBenchmarks/SharpSevenZipBenchmarks.csproj
+++ b/SharpSevenZip/SharpSevenZipBenchmarks/SharpSevenZipBenchmarks.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="PolySharp" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SharpCompress" Version="0.38.0" />
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.6.2.24" />
   </ItemGroup>
 


### PR DESCRIPTION
In fact, I did miss three commits with the previous pull request.

Notes:
* The removed try-catch in the first commit served no purpose (`SpecialDetect` doesn't throw it) and it appears the `return` got lost, so `InArchiveFormat.tar` was never hit here.
* udf & mub were never recognized without their actual signatures
* The replacement in `RemoveIllegalCharacters` is effectively a nop on MacOS & Linux (that is, doesn't break them)
* The loop in `ArchiveExtractCallback.cs` was redundant (`Replace` already runs an all chars).
* In `FileChecker.cs`, the `Stream.CanSeek` is required for `stream.Length / stream.Seek`.