### PR TITLE
Enhance archive handling and improve tar detection

### DIFF
--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
@@ -250,6 +250,26 @@ public class SharpSevenZipExtractorTests : TestBase
 
         Assert.That(Directory.GetFiles(OutputDirectory), Has.Length.EqualTo(1));
     }
+
+    [Test]
+    [TestCase("TestData/xz.xz", "xz")]
+    [TestCase("TestData/bzip2.bz2", "bzip2")]
+    [TestCase("TestData/zstd.zst", "zstd")]
+    public void ExtractStandaloneCompressedFileDoesNotAppendTar(string archivePath, string expectedName)
+    {
+        // A standalone compressed file (e.g. file.zst, not file.tar.zst) carries no
+        // inner entry name. Extraction must strip the compression extension and must
+        // NOT append a bogus ".tar" suffix.
+        using (var extractor = new SharpSevenZipExtractor(archivePath))
+        {
+            extractor.ExtractArchive(OutputDirectory);
+        }
+
+        var files = Directory.GetFiles(OutputDirectory);
+
+        Assert.That(files, Has.Length.EqualTo(1));
+        Assert.That(Path.GetFileName(files[0]), Is.EqualTo(expectedName));
+    }
 }
 
 /// <summary>

--- a/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
@@ -243,26 +243,9 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
 
                     if (string.IsNullOrEmpty(entryName))
                     {
-                        if (_filesCount == 1)
-                        {
-                            var archName = Path.GetFileName(_extractor!.FileName);
-                            var dotIndex = archName!.LastIndexOf('.');
-                            if (dotIndex > 0)
-                            {
-                                archName = archName[..dotIndex];
-                            }
-                            if (!archName.EndsWith(".tar",
-                                                   StringComparison.OrdinalIgnoreCase))
-                            {
-                                archName += ".tar";
-                            }
-
-                            entryName = archName;
-                        }
-                        else
-                        {
-                            entryName = $"[no name] {index.ToString(CultureInfo.InvariantCulture)}";
-                        }
+                        entryName = _filesCount == 1
+                            ? GetDefaultSingleEntryName(Path.GetFileName(_extractor!.FileName))
+                            : $"[no name] {index.ToString(CultureInfo.InvariantCulture)}";
                     }
 
                     #endregion
@@ -517,6 +500,53 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
             catch (ObjectDisposedException) { }
             _fakeStream = null;
         }
+    }
+
+    /// <summary>
+    /// Compact tar-compression extensions whose single compressed stream is itself a
+    /// tar archive, e.g. ".tgz" == ".tar.gz", ".txz" == ".tar.xz", ".tzst" == ".tar.zst".
+    /// </summary>
+    private static readonly HashSet<string> _tarShorthandExtensions =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "tgz", "tpz",                 // tar + gzip
+            "taz",                        // tar + gzip / compress (old .Z)
+            "tz",                         // tar + compress (.tar.Z, very old)
+            "tbz", "tbz2", "tb2", "tz2",  // tar + bzip2
+            "txz",                        // tar + xz
+            "tlz",                        // tar + lzma / lzip
+            "tzst",                       // tar + zstd
+        };
+
+    /// <summary>
+    /// Derives the inner file name for a single-stream archive (e.g. a standalone
+    /// .gz/.xz/.bz2/.zst file) whose only entry carries no stored name.
+    /// </summary>
+    /// <param name="archiveFileName">The archive file name, without directory.</param>
+    /// <returns>
+    /// The archive name with its trailing compression extension removed. For the compact
+    /// tar extensions (.tgz, .txz, .tzst, ...) the implicit ".tar" suffix is restored;
+    /// for every other format no ".tar" is appended. An explicit ".tar" already present
+    /// in the name (e.g. "foo.tar.gz") is preserved by removing only the last extension.
+    /// </returns>
+    private static string GetDefaultSingleEntryName(string? archiveFileName)
+    {
+        // Stream-based extraction may not know the archive's original file name.
+        if (string.IsNullOrEmpty(archiveFileName))
+        {
+            return "[no name] 0";
+        }
+
+        var extension = Path.GetExtension(archiveFileName);
+
+        if (extension.Length > 1 && _tarShorthandExtensions.Contains(extension[1..]))
+        {
+            return Path.GetFileNameWithoutExtension(archiveFileName) + ".tar";
+        }
+
+        var baseName = Path.GetFileNameWithoutExtension(archiveFileName);
+
+        return string.IsNullOrEmpty(baseName) ? archiveFileName! : baseName;
     }
 
     /// <summary>

--- a/SharpSevenZip/SharpSevenZip/ArchiveFormatInfo.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveFormatInfo.cs
@@ -1,0 +1,45 @@
+namespace SharpSevenZip;
+
+/// <summary>
+/// The result of probing a file or stream for its archive format. Carries everything
+/// <see cref="SharpSevenZipExtractor"/> needs to open the archive, so a caller that has
+/// already probed the format does not pay for signature detection a second time.
+/// </summary>
+public readonly record struct ArchiveFormatInfo
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveFormatInfo"/> struct.
+    /// </summary>
+    /// <param name="format">The detected archive format.</param>
+    /// <param name="offset">The byte offset at which the archive begins.</param>
+    /// <param name="isExecutable">True when the input is a PE executable.</param>
+    internal ArchiveFormatInfo(InArchiveFormat format, int offset, bool isExecutable)
+    {
+        Format = format;
+        Offset = offset;
+        IsExecutable = isExecutable;
+    }
+
+    /// <summary>
+    /// Gets the detected archive format, or <see cref="InArchiveFormat.None"/> when the
+    /// input is not a recognised archive.
+    /// </summary>
+    public InArchiveFormat Format { get; }
+
+    /// <summary>
+    /// Gets the byte offset at which the archive content begins. Non-zero for
+    /// self-extracting or otherwise embedded archives.
+    /// </summary>
+    public int Offset { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the input is a PE executable (which may, but need
+    /// not, be a self-extracting archive).
+    /// </summary>
+    public bool IsExecutable { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a recognised archive format was found.
+    /// </summary>
+    public bool IsArchive => Format != InArchiveFormat.None;
+}

--- a/SharpSevenZip/SharpSevenZip/FileChecker.cs
+++ b/SharpSevenZip/SharpSevenZip/FileChecker.cs
@@ -319,4 +319,48 @@ internal static class FileChecker
             return Formats.FormatByFileName(fileName, true);
         }
     }
+
+    /// <summary>
+    /// Probes a file for its archive format without throwing when it is not an archive.
+    /// </summary>
+    /// <param name="fileName">The file name to identify.</param>
+    /// <param name="info">The full detection result; <see cref="ArchiveFormatInfo.Format"/>
+    /// is <see cref="InArchiveFormat.None"/> when nothing was recognised.</param>
+    /// <returns>True when a recognised archive format was found; otherwise, false.</returns>
+    public static bool TryCheckSignature(string fileName, out ArchiveFormatInfo info)
+    {
+        try
+        {
+            var format = CheckSignature(fileName, out var offset, out var isExecutable);
+            info = new ArchiveFormatInfo(format, offset, isExecutable);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            info = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Probes a stream for its archive format without throwing when it is not an archive.
+    /// </summary>
+    /// <param name="stream">The stream to identify.</param>
+    /// <param name="info">The full detection result; <see cref="ArchiveFormatInfo.Format"/>
+    /// is <see cref="InArchiveFormat.None"/> when nothing was recognised.</param>
+    /// <returns>True when a recognised archive format was found; otherwise, false.</returns>
+    public static bool TryCheckSignature(Stream stream, out ArchiveFormatInfo info)
+    {
+        try
+        {
+            var format = CheckSignature(stream, out var offset, out var isExecutable);
+            info = new ArchiveFormatInfo(format, offset, isExecutable);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            info = default;
+            return false;
+        }
+    }
 }

--- a/SharpSevenZip/SharpSevenZip/FileChecker.cs
+++ b/SharpSevenZip/SharpSevenZip/FileChecker.cs
@@ -53,6 +53,84 @@ internal static class FileChecker
     }
 
     /// <summary>
+    /// Validates the 512-byte tar header at the start of the stream by recomputing its
+    /// checksum. This recognises every tar variant (v7, ustar, GNU, pax) without relying
+    /// on the "ustar" magic and, crucially, rejects zero-padded non-tar binaries that merely
+    /// end in zero bytes.
+    /// </summary>
+    private static bool IsValidTarHeader(Stream stream)
+    {
+        const int BlockSize = 512;
+        const int ChecksumOffset = 148;
+        const int ChecksumLength = 8;
+
+        if (stream.Length < BlockSize)
+        {
+            return false;
+        }
+
+        var header = new byte[BlockSize];
+        stream.Seek(0, SeekOrigin.Begin);
+        ReadFully(stream, header, 0, BlockSize);
+
+        var storedChecksum = ParseOctal(header, ChecksumOffset, ChecksumLength);
+        if (storedChecksum < 0)
+        {
+            return false;
+        }
+
+        // The stored checksum is computed with the checksum field itself read as spaces.
+        // Compare against both the unsigned and signed byte sums, since historic writers
+        // disagreed on the signedness of bytes >= 0x80.
+        long unsignedSum = 0;
+        long signedSum = 0;
+        for (var i = 0; i < BlockSize; i++)
+        {
+            var b = i is >= ChecksumOffset and < ChecksumOffset + ChecksumLength ? (byte)0x20 : header[i];
+            unsignedSum += b;
+            signedSum += (sbyte)b;
+        }
+
+        return storedChecksum == unsignedSum || storedChecksum == signedSum;
+    }
+
+    /// <summary>
+    /// Parses a NUL/space padded octal ASCII number from a header field.
+    /// Returns -1 when the field holds no valid octal digits.
+    /// </summary>
+    private static long ParseOctal(byte[] buffer, int offset, int length)
+    {
+        var i = offset;
+        var end = offset + length;
+
+        while (i < end && (buffer[i] == (byte)' ' || buffer[i] == 0))
+        {
+            i++;
+        }
+
+        long value = 0;
+        var any = false;
+        for (; i < end; i++)
+        {
+            var b = buffer[i];
+            if (b == (byte)' ' || b == 0)
+            {
+                break;
+            }
+
+            if (b is < (byte)'0' or > (byte)'7')
+            {
+                return -1;
+            }
+
+            value = (value << 3) + (b - '0');
+            any = true;
+        }
+
+        return any ? value : -1;
+    }
+
+    /// <summary>
     /// Gets the InArchiveFormat for a specific extension.
     /// </summary>
     /// <param name="stream">The stream to identify.</param>
@@ -156,18 +234,19 @@ internal static class FileChecker
             return InArchiveFormat.Vdi;
         }
 
-        #region Last resort for tar - can mistake
+        #region Last resort for tar
 
-        if (suspectedFormat == null && stream.Length >= 1024)
+        // Tars whose first header lacks the POSIX "ustar" magic (old v7 / pre-POSIX GNU
+        // tars) are not caught by the SpecialDetect("ustar") check above. Validate the
+        // 512-byte header checksum instead of guessing from trailing zero padding: the
+        // former heuristic ("the last 1024 bytes are all zero") also matches zero-padded
+        // binaries – SquashFS images, Linux bzImage kernels, EFI stubs and firmware blobs –
+        // which were misdetected as TAR and then failed on open with the misleading
+        // "decided it is TAR by mistake" error. A valid checksum is present in every real
+        // tar header (all variants) and absent from those binaries.
+        if (suspectedFormat == null && IsValidTarHeader(stream))
         {
-            stream.Seek(-1024, SeekOrigin.End);
-            var buf = new byte[1024];
-            ReadFully(stream, buf, 0, buf.Length);
-
-            if (Array.TrueForAll(buf, b => b == 0))
-            {
-                return InArchiveFormat.Tar;
-            }
+            return InArchiveFormat.Tar;
         }
 
         #endregion

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipArchiveFormat.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipArchiveFormat.cs
@@ -50,4 +50,28 @@ public static class SharpSevenZipArchiveFormat
     {
         return FileChecker.CheckSignature(fileName, out offset, out isExecutable);
     }
+
+    /// <summary>
+    /// Probes a file for its archive format without throwing when it is not a recognised archive.
+    /// </summary>
+    /// <param name="fileName">The archive file name.</param>
+    /// <param name="info">The full detection result (format, offset and executable flag). Pass it to
+    /// <see cref="SharpSevenZipExtractor(string, ArchiveFormatInfo)"/> to open the archive without
+    /// detecting the signature again.</param>
+    /// <returns>True when a recognised archive format was found; otherwise, false.</returns>
+    public static bool TryCheckFormat(string fileName, out ArchiveFormatInfo info)
+    {
+        return FileChecker.TryCheckSignature(fileName, out info);
+    }
+
+    /// <summary>
+    /// Probes a stream for its archive format without throwing when it is not a recognised archive.
+    /// </summary>
+    /// <param name="stream">The stream to identify.</param>
+    /// <param name="info">The full detection result (format, offset and executable flag).</param>
+    /// <returns>True when a recognised archive format was found; otherwise, false.</returns>
+    public static bool TryCheckFormat(Stream stream, out ArchiveFormatInfo info)
+    {
+        return FileChecker.TryCheckSignature(stream, out info);
+    }
 }

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
@@ -34,6 +34,7 @@ public sealed partial class SharpSevenZipExtractor
     private bool _opened;
     private bool _disposed;
     private InArchiveFormat _format = InArchiveFormat.None;
+    private bool _isExecutable;
     private ReadOnlyCollection<ArchiveFileInfo>? _archiveFileInfoCollection;
     private ReadOnlyCollection<ArchiveProperty>? _archiveProperties;
     private ReadOnlyCollection<string>? _volumeFileNames;
@@ -53,7 +54,11 @@ public sealed partial class SharpSevenZipExtractor
     private void Init(string archiveFullName)
     {
         _fileName = archiveFullName;
-        var isExecutable = false;
+        // When the format was supplied by the caller (e.g. via a prior
+        // SharpSevenZipArchiveFormat.TryCheckFormat probe), reuse its detection result
+        // instead of scanning the signature a second time. _offset and _isExecutable were
+        // seeded together with _format, so the PE re-check below stays faithful.
+        var isExecutable = _isExecutable;
 
         if (_format == InArchiveFormat.None)
         {
@@ -101,7 +106,7 @@ public sealed partial class SharpSevenZipExtractor
     private void Init(Stream stream)
     {
         ValidateStream(stream);
-        var isExecutable = false;
+        var isExecutable = _isExecutable;
 
         if (_format == InArchiveFormat.None)
         {
@@ -195,6 +200,20 @@ public sealed partial class SharpSevenZipExtractor
     }
 
     /// <summary>
+    /// Initializes a new instance of SharpSevenZipExtractor class from an already probed format.
+    /// </summary>
+    /// <param name="archiveFullName">The archive full file name.</param>
+    /// <param name="formatInfo">The detection result obtained from
+    /// <see cref="SharpSevenZipArchiveFormat.TryCheckFormat(string, out ArchiveFormatInfo)"/>.
+    /// Reusing it avoids re-reading the archive signature. A <see cref="InArchiveFormat.None"/>
+    /// format falls back to automatic detection.</param>
+    public SharpSevenZipExtractor(string archiveFullName, ArchiveFormatInfo formatInfo)
+    {
+        ApplyFormatInfo(formatInfo);
+        Init(archiveFullName);
+    }
+
+    /// <summary>
     /// Initializes a new instance of SharpSevenZipExtractor class.
     /// </summary>
     /// <param name="archiveFullName">The archive full file name.</param>
@@ -216,6 +235,33 @@ public sealed partial class SharpSevenZipExtractor
         : base(password)
     {
         Init(archiveFullName);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of SharpSevenZipExtractor class from an already probed format.
+    /// </summary>
+    /// <param name="archiveFullName">The archive full file name.</param>
+    /// <param name="password">Password for an encrypted archive.</param>
+    /// <param name="formatInfo">The detection result obtained from
+    /// <see cref="SharpSevenZipArchiveFormat.TryCheckFormat(string, out ArchiveFormatInfo)"/>.
+    /// Reusing it avoids re-reading the archive signature on every password attempt. A
+    /// <see cref="InArchiveFormat.None"/> format falls back to automatic detection.</param>
+    public SharpSevenZipExtractor(string archiveFullName, string password, ArchiveFormatInfo formatInfo)
+        : base(password)
+    {
+        ApplyFormatInfo(formatInfo);
+        Init(archiveFullName);
+    }
+
+    /// <summary>
+    /// Seeds the fields the <see cref="Init(string)"/> / <see cref="Init(Stream)"/> detection
+    /// step would otherwise compute, so a caller-supplied probe result is reused verbatim.
+    /// </summary>
+    private void ApplyFormatInfo(ArchiveFormatInfo formatInfo)
+    {
+        _format = formatInfo.Format;
+        _offset = formatInfo.Offset;
+        _isExecutable = formatInfo.IsExecutable;
     }
 
     /// <summary>

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipLibraryManager.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipLibraryManager.cs
@@ -460,6 +460,8 @@ internal static class SharpSevenZipLibraryManager
                 {
                     createObject(ref classId, ref interfaceId, out nint resultPtr);
                     result = (IInArchive)_comWrappers.GetOrCreateObjectForComInstance(resultPtr, CreateObjectFlags.None);
+
+                    _ = System.Runtime.InteropServices.Marshal.Release(resultPtr);
                 }
                 catch (Exception)
                 {
@@ -526,6 +528,8 @@ internal static class SharpSevenZipLibraryManager
 
                     InitUserOutFormat(user, format);
                     _outArchives[user][format] = (IOutArchive)_comWrappers.GetOrCreateObjectForComInstance(resultPtr, CreateObjectFlags.None);
+
+                    _ = System.Runtime.InteropServices.Marshal.Release(resultPtr);
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
Three fixes…

* Prevent `.tar` from being appended to files that were compressed with tar-typical algorithms yet not actually tar archived; add an explicit check for ones that are both compressed *and* archived, whose extension names actually were folded.
* Fix last-resort tar detection to validate the actual tar format instead of misidentifying formats that merely end with trailing zeros.
* Fix a missing reference release that will deadlock the system on .NET 8.0+ when extracting many files.

… and a new API to avoid redundant format probing:

* Add `ArchiveFormatInfo` and probe functions that return it, allowing callers to decide early (e.g., abort) or reuse the result for repeated operations.