### PR TITLE
Improve asynchronous compressor tests and enhance archive extraction

### DIFF
--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipCompressorAsynchronousTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipCompressorAsynchronousTests.cs
@@ -5,6 +5,8 @@ namespace SharpSevenZip.Tests;
 [TestFixture]
 public class SharpSevenZipCompressorAsynchronousTests : TestBase
 {
+    private static readonly TimeSpan CompressionTimeout = TimeSpan.FromSeconds(10);
+
     [Test]
     public void AsynchronousCompressDirectoryAndEventsTest()
     {
@@ -12,39 +14,28 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
         var fileCompressionStartedInvoked = 0;
         var fileCompressionFinishedInvoked = 0;
         var compressingInvoked = 0;
-        var compressionFinishedInvoked = 0;
+        using var compressionFinished = new ManualResetEventSlim(false);
 
         var compressor = new SharpSevenZipCompressor();
 
-        compressor.FilesFound += (o, e) => filesFoundInvoked++;
-        compressor.FileCompressionStarted += (o, e) => fileCompressionStartedInvoked++;
-        compressor.FileCompressionFinished += (o, e) => fileCompressionFinishedInvoked++;
-        compressor.Compressing += (o, e) => compressingInvoked++;
-        compressor.CompressionFinished += (o, e) => compressionFinishedInvoked++;
+        compressor.FilesFound += (o, e) => Interlocked.Increment(ref filesFoundInvoked);
+        compressor.FileCompressionStarted += (o, e) => Interlocked.Increment(ref fileCompressionStartedInvoked);
+        compressor.FileCompressionFinished += (o, e) => Interlocked.Increment(ref fileCompressionFinishedInvoked);
+        compressor.Compressing += (o, e) => Interlocked.Increment(ref compressingInvoked);
+        compressor.CompressionFinished += (o, e) => compressionFinished.Set();
 
         compressor.BeginCompressDirectory(@"TestData", TemporaryFile);
 
-        var timeToWait = 10000;
-        while (compressionFinishedInvoked == 0)
-        {
-            if (timeToWait <= 0)
-            {
-                break;
-            }
-
-            Thread.Sleep(25);
-            //timeToWait -= 25;
-        }
+        Assert.That(compressionFinished.Wait(CompressionTimeout), Is.True, "Compression did not finish in time.");
 
         var numberOfTestDataFiles = Directory.GetFiles("TestData").Length;
 
         Assert.Multiple((Action)delegate
         {
-            Assert.That(filesFoundInvoked, Is.EqualTo(1));
-            Assert.That(fileCompressionStartedInvoked, Is.EqualTo(numberOfTestDataFiles));
-            Assert.That(fileCompressionFinishedInvoked, Is.EqualTo(numberOfTestDataFiles));
+            Assert.That(Volatile.Read(ref filesFoundInvoked), Is.EqualTo(1));
+            Assert.That(Volatile.Read(ref fileCompressionStartedInvoked), Is.EqualTo(numberOfTestDataFiles));
+            Assert.That(Volatile.Read(ref fileCompressionFinishedInvoked), Is.EqualTo(numberOfTestDataFiles));
             // Assert.That(compressingInvoked, Is.EqualTo(numberOfTestDataFiles));
-            Assert.That(compressionFinishedInvoked, Is.EqualTo(1));
 
             Assert.That(File.Exists(TemporaryFile), Is.True);
         });
@@ -53,24 +44,14 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
     [Test]
     public void AsynchronousCompressFilesTest()
     {
-        var compressionFinishedInvoked = false;
+        using var compressionFinished = new ManualResetEventSlim(false);
 
         var compressor = new SharpSevenZipCompressor { DirectoryStructure = false };
-        compressor.CompressionFinished += (o, e) => compressionFinishedInvoked = true;
+        compressor.CompressionFinished += (o, e) => compressionFinished.Set();
 
         compressor.BeginCompressFiles(TemporaryFile, @"TestData/zip.zip", @"TestData/tar.tar");
 
-        var timeToWait = 10000;
-        while (!compressionFinishedInvoked)
-        {
-            if (timeToWait <= 0)
-            {
-                break;
-            }
-
-            Thread.Sleep(25);
-            //timeToWait -= 25;
-        }
+        Assert.That(compressionFinished.Wait(CompressionTimeout), Is.True, "Compression did not finish in time.");
 
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
@@ -87,27 +68,17 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
     [Test]
     public void AsynchronousCompressStreamTest()
     {
-        var compressionFinishedInvoked = false;
+        using var compressionFinished = new ManualResetEventSlim(false);
 
         var compressor = new SharpSevenZipCompressor { DirectoryStructure = false };
-        compressor.CompressionFinished += (o, e) => compressionFinishedInvoked = true;
+        compressor.CompressionFinished += (o, e) => compressionFinished.Set();
 
         using (var inputStream = File.OpenRead(@"TestData/zip.zip"))
         {
             using var outputStream = new FileStream(TemporaryFile, FileMode.Create);
             compressor.BeginCompressStream(inputStream, outputStream);
 
-            var timeToWait = 10000;
-            while (!compressionFinishedInvoked)
-            {
-                if (timeToWait <= 0)
-                {
-                    break;
-                }
-
-                Thread.Sleep(25);
-                //timeToWait -= 25;
-            }
+            Assert.That(compressionFinished.Wait(CompressionTimeout), Is.True, "Compression did not finish in time.");
         }
 
         Assert.That(File.Exists(TemporaryFile), Is.True);
@@ -123,22 +94,12 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
 
         compressor.CompressFiles(TemporaryFile, @"TestData/tar.tar");
 
-        var compressionFinishedInvoked = false;
-        compressor.CompressionFinished += (o, e) => compressionFinishedInvoked = true;
+        using var compressionFinished = new ManualResetEventSlim(false);
+        compressor.CompressionFinished += (o, e) => compressionFinished.Set();
 
         compressor.BeginModifyArchive(TemporaryFile, new Dictionary<int, string?> { { 0, @"tartar" } });
 
-        var timeToWait = 10000;
-        while (!compressionFinishedInvoked)
-        {
-            if (timeToWait <= 0)
-            {
-                break;
-            }
-
-            Thread.Sleep(25);
-            //timeToWait -= 25;
-        }
+        Assert.That(compressionFinished.Wait(CompressionTimeout), Is.True, "Compression did not finish in time.");
 
         Assert.That(File.Exists(TemporaryFile), Is.True);
 
@@ -153,24 +114,14 @@ public class SharpSevenZipCompressorAsynchronousTests : TestBase
     [Test]
     public void AsynchronousCompressFilesEncryptedTest()
     {
-        var compressionFinishedInvoked = false;
+        using var compressionFinished = new ManualResetEventSlim(false);
 
         var compressor = new SharpSevenZipCompressor { DirectoryStructure = false };
-        compressor.CompressionFinished += (o, e) => compressionFinishedInvoked = true;
+        compressor.CompressionFinished += (o, e) => compressionFinished.Set();
 
         compressor.BeginCompressFilesEncrypted(TemporaryFile, "secure", @"TestData/zip.zip", @"TestData/tar.tar");
 
-        var timeToWait = 10000;
-        while (!compressionFinishedInvoked)
-        {
-            if (timeToWait <= 0)
-            {
-                break;
-            }
-
-            Thread.Sleep(25);
-            //timeToWait -= 25;
-        }
+        Assert.That(compressionFinished.Wait(CompressionTimeout), Is.True, "Compression did not finish in time.");
 
         Assert.That(File.Exists(TemporaryFile), Is.True);
 

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
@@ -450,6 +450,42 @@ public class SharpSevenZipExtractorTests : TestBase
 
         return archive;
     }
+
+    [Test]
+    public void TruncatedArchiveReportsUnexpectedEnd()
+    {
+        // A truncated zip still opens and extracts the entries it can reach, so the only
+        // signal that the rest is missing is the flag 7-Zip sets on the archive.
+        var archive = Truncate(@"TestData/zip.zip", "truncated.zip");
+
+        using var extractor = new SharpSevenZipExtractor(archive);
+        extractor.ExtractArchive(OutputDirectory);
+
+        Assert.That(extractor.ErrorFlags, Is.EqualTo(ArchiveErrorFlags.UnexpectedEnd));
+    }
+
+    [Test]
+    public void IntactArchiveReportsNoErrorFlags()
+    {
+        using var extractor = new SharpSevenZipExtractor(@"TestData/multiple_files.7z");
+
+        Assert.Multiple((Action)delegate
+        {
+            Assert.That(extractor.ErrorFlags, Is.EqualTo(ArchiveErrorFlags.None));
+            Assert.That(extractor.WarningFlags, Is.EqualTo(ArchiveErrorFlags.None));
+            Assert.That(extractor.ErrorMessage, Is.Null);
+            Assert.That(extractor.WarningMessage, Is.Null);
+        });
+    }
+
+    private static string Truncate(string source, string name)
+    {
+        var bytes = File.ReadAllBytes(source);
+        var target = Path.Combine(OutputDirectory, name);
+        File.WriteAllBytes(target, bytes.Take(bytes.Length * 2 / 3).ToArray());
+
+        return target;
+    }
 }
 
 /// <summary>

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
@@ -1,8 +1,13 @@
+using System.Text;
+
 namespace SharpSevenZip.Tests;
 
 [TestFixture]
 public class SharpSevenZipExtractorTests : TestBase
 {
+    private const string ZoneIdentifier = "[ZoneTransfer]\r\nZoneId=3\r\nHostUrl=https://example.com/multiple_files.7z\r\n";
+    private const string OtherZoneIdentifier = "[ZoneTransfer]\r\nZoneId=2\r\nHostUrl=https://example.org/other.7z\r\n";
+
     public static List<TestFile> TestFiles
     {
         get
@@ -348,6 +353,102 @@ public class SharpSevenZipExtractorTests : TestBase
         File.Move(archive, moved);
 
         Assert.That(File.Exists(moved), Is.True);
+    }
+
+    [Test]
+    public void ExtractArchivePropagatesTheMarkOfTheWeb()
+    {
+        var archive = MarkedArchive();
+        var target = Path.Combine(OutputDirectory, "extracted");
+
+        using (var extractor = new SharpSevenZipExtractor(archive))
+        {
+            extractor.ExtractArchive(target);
+        }
+
+        Assert.That(MarkOfTheWeb.Read(Path.Combine(target, "file1.txt")),
+            Is.EqualTo(Encoding.ASCII.GetBytes(ZoneIdentifier)));
+    }
+
+    [Test]
+    public void ExtractArchiveKeepsTheMarkOfTheWebOfTheOpenedArchive()
+    {
+        // The zone stream is read once up front, so replacing it mid-extraction must not
+        // give later entries a different mark than the first one.
+        var archive = MarkedArchive();
+        var target = Path.Combine(OutputDirectory, "extracted");
+
+        using (var extractor = new SharpSevenZipExtractor(archive))
+        {
+            extractor.FileExtractionStarted += (_, e) =>
+            {
+                if (e.FileInfo.Index == 0)
+                {
+                    MarkOfTheWeb.Apply(Encoding.ASCII.GetBytes(OtherZoneIdentifier), archive);
+                }
+            };
+
+            extractor.ExtractArchive(target);
+        }
+
+        Assert.Multiple((Action)delegate
+        {
+            Assert.That(MarkOfTheWeb.Read(Path.Combine(target, "file1.txt")),
+                Is.EqualTo(Encoding.ASCII.GetBytes(ZoneIdentifier)));
+            Assert.That(MarkOfTheWeb.Read(Path.Combine(target, "file3.txt")),
+                Is.EqualTo(Encoding.ASCII.GetBytes(ZoneIdentifier)));
+        });
+    }
+
+    [Test]
+    public void ExtractArchiveRestoresTimestampsOfMarkedFiles()
+    {
+        // Writing an alternate data stream stamps the base file with the current time, so
+        // the zone stream has to be written before the archived timestamp is restored.
+        var archive = MarkedArchive();
+        var target = Path.Combine(OutputDirectory, "extracted");
+        DateTime stored;
+
+        using (var extractor = new SharpSevenZipExtractor(archive))
+        {
+            stored = extractor.ArchiveFileData[0].LastWriteTime;
+            extractor.ExtractArchive(target);
+        }
+
+        Assert.That(File.GetLastWriteTime(Path.Combine(target, "file1.txt")), Is.EqualTo(stored));
+    }
+
+    [Test]
+    public void ExtractArchiveWithoutPropagationLeavesFilesUnmarked()
+    {
+        var archive = MarkedArchive();
+        var target = Path.Combine(OutputDirectory, "extracted");
+
+        using (var extractor = new SharpSevenZipExtractor(archive))
+        {
+            extractor.PropagateMarkOfTheWeb = false;
+            extractor.ExtractArchive(target);
+        }
+
+        Assert.That(MarkOfTheWeb.Read(Path.Combine(target, "file1.txt")), Is.Null);
+    }
+
+    /// <summary>
+    /// Copies the multi-entry test archive into the output directory and gives it a
+    /// Mark-of-the-Web.
+    /// </summary>
+    private static string MarkedArchive()
+    {
+        var archive = Path.GetFullPath(Path.Combine(OutputDirectory, "marked.7z"));
+        File.Copy(@"TestData/multiple_files.7z", archive, overwrite: true);
+        MarkOfTheWeb.Apply(Encoding.ASCII.GetBytes(ZoneIdentifier), archive);
+
+        if (MarkOfTheWeb.Read(archive) is null)
+        {
+            Assert.Ignore("The file system does not support Zone.Identifier alternate data streams.");
+        }
+
+        return archive;
     }
 }
 

--- a/SharpSevenZip/SharpSevenZip/ArchiveErrorFlags.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveErrorFlags.cs
@@ -1,0 +1,69 @@
+namespace SharpSevenZip;
+
+/// <summary>
+/// Problems 7-Zip reports for an archive it has opened. Mirrors 7-Zip's
+/// <c>kpv_ErrorFlags_*</c> values.
+/// </summary>
+[Flags]
+public enum ArchiveErrorFlags
+{
+    /// <summary>
+    /// No problem was reported.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The data was not recognized as an archive of this format.
+    /// </summary>
+    IsNotArchive = 1 << 0,
+
+    /// <summary>
+    /// The headers are damaged.
+    /// </summary>
+    HeadersError = 1 << 1,
+
+    /// <summary>
+    /// The encrypted headers could not be decoded.
+    /// </summary>
+    EncryptedHeadersError = 1 << 2,
+
+    /// <summary>
+    /// The archive begins before the start of the available data.
+    /// </summary>
+    UnavailableStart = 1 << 3,
+
+    /// <summary>
+    /// The start of the archive could not be confirmed.
+    /// </summary>
+    UnconfirmedStart = 1 << 4,
+
+    /// <summary>
+    /// The archive is truncated.
+    /// </summary>
+    UnexpectedEnd = 1 << 5,
+
+    /// <summary>
+    /// The archive is followed by data that is not part of it.
+    /// </summary>
+    DataAfterEnd = 1 << 6,
+
+    /// <summary>
+    /// The archive uses a compression method this build cannot decode.
+    /// </summary>
+    UnsupportedMethod = 1 << 7,
+
+    /// <summary>
+    /// The archive uses a format feature this build does not implement.
+    /// </summary>
+    UnsupportedFeature = 1 << 8,
+
+    /// <summary>
+    /// The archive contains damaged data.
+    /// </summary>
+    DataError = 1 << 9,
+
+    /// <summary>
+    /// A checksum stored in the archive does not match.
+    /// </summary>
+    CrcError = 1 << 10
+}

--- a/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveExtractCallback.cs
@@ -38,6 +38,7 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
     private uint? _fileIndex;
     private int _filesCount;
     private OutStreamWrapper? _fileStream;
+    private byte[]? _markOfTheWeb;
     private Stream? _baseStream;
     private bool _directoryStructure;
     private int _currentIndex;
@@ -133,6 +134,8 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
         _fakeStream = new FakeOutStreamWrapper();
         _fakeStream.BytesWritten += IntEventArgsHandler;
         _extractor = extractor;
+        // One snapshot for the whole extraction: the archive file must not be re-read per entry.
+        _markOfTheWeb = extractor.PropagateMarkOfTheWeb ? MarkOfTheWeb.Read(extractor.FileName) : null;
         //GC.AddMemoryPressure(MemoryPressure);
     }
     #endregion
@@ -329,7 +332,7 @@ internal sealed partial class ArchiveExtractCallback : CallbackBase, IArchiveExt
 
                         try
                         {
-                            _fileStream = new OutStreamWrapper(File.Create(fileName), fileName, time, true);
+                            _fileStream = new OutStreamWrapper(File.Create(fileName), fileName, time, true, _markOfTheWeb);
                         }
                         catch (Exception e)
                         {

--- a/SharpSevenZip/SharpSevenZip/MarkOfTheWeb.cs
+++ b/SharpSevenZip/SharpSevenZip/MarkOfTheWeb.cs
@@ -1,0 +1,132 @@
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+namespace SharpSevenZip;
+
+/// <summary>
+/// Reads and writes the NTFS <c>Zone.Identifier</c> alternate data stream that carries a
+/// file's Mark-of-the-Web.
+/// </summary>
+internal static partial class MarkOfTheWeb
+{
+    private const string ZoneIdentifierStream = ":Zone.Identifier";
+
+    private const uint GenericRead = 0x80000000;
+    private const uint GenericWrite = 0x40000000;
+    private const uint FileShareRead = 0x00000001;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint CreateAlways = 2;
+    private const uint OpenExisting = 3;
+    private const uint FileAttributeNormal = 0x00000080;
+
+    /// <summary>
+    /// A zone stream holds a short INI section; the bound is the one 7-Zip applies.
+    /// </summary>
+    private const long MaxLength = 1 << 15;
+
+    /// <summary>
+    /// Reads the Mark-of-the-Web of a file.
+    /// </summary>
+    /// <param name="fileName">The file to read the zone stream of.</param>
+    /// <returns>The raw zone stream, or <c>null</c> if the file carries none.</returns>
+    public static byte[]? Read(string? fileName)
+    {
+        if (fileName is null || fileName.Length == 0 || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = Open(fileName + ZoneIdentifierStream, GenericRead,
+                FileShareRead | FileShareWrite, OpenExisting, FileAccess.Read);
+
+            if (stream is null || stream.Length == 0 || stream.Length >= MaxLength)
+            {
+                return null;
+            }
+
+            var zone = new byte[stream.Length];
+
+            for (var offset = 0; offset < zone.Length;)
+            {
+                var count = stream.Read(zone, offset, zone.Length - offset);
+
+                if (count == 0)
+                {
+                    return null;
+                }
+
+                offset += count;
+            }
+
+            return zone;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes a Mark-of-the-Web to a file, replacing any zone stream it already has.
+    /// </summary>
+    /// <param name="zone">The raw zone stream to write. Nothing happens when it is <c>null</c>.</param>
+    /// <param name="fileName">The file to write the zone stream to.</param>
+    public static void Apply(byte[]? zone, string? fileName)
+    {
+        if (zone is null || zone.Length == 0
+            || fileName is null || fileName.Length == 0
+            || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        try
+        {
+            // A FAT or exFAT target has no alternate data streams, so the zone is dropped.
+            using var stream = Open(fileName + ZoneIdentifierStream, GenericWrite,
+                0, CreateAlways, FileAccess.Write);
+
+            stream?.Write(zone, 0, zone.Length);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static FileStream? Open(string streamName, uint access, uint shareMode, uint creationDisposition, FileAccess fileAccess)
+    {
+        var handle = CreateFile(streamName, access, shareMode, IntPtr.Zero, creationDisposition, FileAttributeNormal, IntPtr.Zero);
+
+        if (handle.IsInvalid)
+        {
+            handle.Dispose();
+            return null;
+        }
+
+        return new FileStream(handle, fileAccess);
+    }
+
+#if NET8_0_OR_GREATER
+    [LibraryImport("kernel32.dll", EntryPoint = "CreateFileW", StringMarshalling = StringMarshalling.Utf16)]
+    private static partial SafeFileHandle CreateFile(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
+#else
+    [DllImport("kernel32.dll", EntryPoint = "CreateFileW", CharSet = CharSet.Unicode)]
+    private static extern SafeFileHandle CreateFile(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
+#endif
+}

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
@@ -31,6 +31,10 @@ public sealed partial class SharpSevenZipExtractor
     private long? _unpackedSize;
     private uint? _filesCount;
     private bool? _isSolid;
+    private ArchiveErrorFlags _errorFlags;
+    private ArchiveErrorFlags _warningFlags;
+    private string? _errorMessage;
+    private string? _warningMessage;
     private bool _opened;
     private bool _disposed;
     private InArchiveFormat _format = InArchiveFormat.None;
@@ -583,11 +587,26 @@ public sealed partial class SharpSevenZipExtractor
                 _filesCount = _archive.GetNumberOfItems();
                 _archiveFileData = new List<ArchiveFileInfo>((int)_filesCount);
 
-                if (_filesCount != 0)
-                {
-                    var data = new PropVariant();
+                var data = new PropVariant();
 
-                    try
+                try
+                {
+                    #region Getting archive diagnostics
+
+                    // No handler lists these among its archive properties, so they can only
+                    // be asked for by id.
+                    _archive.GetArchiveProperty(ItemPropId.ErrorFlags, ref data);
+                    _errorFlags = (ArchiveErrorFlags)NativeMethods.SafeCast<uint>(data, 0);
+                    _archive.GetArchiveProperty(ItemPropId.WarningFlags, ref data);
+                    _warningFlags = (ArchiveErrorFlags)NativeMethods.SafeCast<uint>(data, 0);
+                    _archive.GetArchiveProperty(ItemPropId.Error, ref data);
+                    _errorMessage = NativeMethods.SafeCast<string?>(data, null);
+                    _archive.GetArchiveProperty(ItemPropId.Warning, ref data);
+                    _warningMessage = NativeMethods.SafeCast<string?>(data, null);
+
+                    #endregion
+
+                    if (_filesCount != 0)
                     {
                         #region Getting archive items data
 
@@ -676,12 +695,12 @@ public sealed partial class SharpSevenZipExtractor
 
                         #endregion
                     }
-                    catch (Exception)
+                }
+                catch (Exception)
+                {
+                    if (openCallback.ThrowException())
                     {
-                        if (openCallback.ThrowException())
-                        {
-                            throw;
-                        }
+                        throw;
                     }
                 }
             }
@@ -1020,6 +1039,64 @@ public sealed partial class SharpSevenZipExtractor
             InitArchiveFileData(true);
 
             return _archiveProperties!;
+        }
+    }
+
+    /// <summary>
+    /// Gets the problems 7-Zip reported for the archive. Anything other than
+    /// <see cref="ArchiveErrorFlags.None"/> means the archive cannot be extracted in full,
+    /// even when extraction itself reports no failure.
+    /// </summary>
+    public ArchiveErrorFlags ErrorFlags
+    {
+        get
+        {
+            DisposedCheck();
+            InitArchiveFileData(true);
+
+            return _errorFlags;
+        }
+    }
+
+    /// <summary>
+    /// Gets the non-fatal problems 7-Zip reported for the archive.
+    /// </summary>
+    public ArchiveErrorFlags WarningFlags
+    {
+        get
+        {
+            DisposedCheck();
+            InitArchiveFileData(true);
+
+            return _warningFlags;
+        }
+    }
+
+    /// <summary>
+    /// Gets the error message the format handler supplied, if any.
+    /// </summary>
+    public string? ErrorMessage
+    {
+        get
+        {
+            DisposedCheck();
+            InitArchiveFileData(true);
+
+            return _errorMessage;
+        }
+    }
+
+    /// <summary>
+    /// Gets the warning message the format handler supplied, if any.
+    /// </summary>
+    public string? WarningMessage
+    {
+        get
+        {
+            DisposedCheck();
+            InitArchiveFileData(true);
+
+            return _warningMessage;
         }
     }
 

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
@@ -436,6 +436,12 @@ public sealed partial class SharpSevenZipExtractor
     /// </summary>
     public bool PreserveDirectoryStructure { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether extracted files inherit the archive's
+    /// Mark-of-the-Web. The default is <c>true</c>.
+    /// </summary>
+    public bool PropagateMarkOfTheWeb { get; set; } = true;
+
     #endregion
 
     /// <summary>

--- a/SharpSevenZip/SharpSevenZip/StreamWrappers.cs
+++ b/SharpSevenZip/SharpSevenZip/StreamWrappers.cs
@@ -32,6 +32,8 @@ internal class StreamWrapper : DisposeVariableWrapper, IDisposable
 
     private readonly DateTime _fileTime;
 
+    private readonly byte[]? _markOfTheWeb;
+
     /// <summary>
     /// Worker stream for reading, writing and seeking.
     /// </summary>
@@ -44,12 +46,14 @@ internal class StreamWrapper : DisposeVariableWrapper, IDisposable
     /// <param name="fileName">File name associated with the stream (for attributes fix)</param>
     /// <param name="time">File last write time (for attributes fix)</param>
     /// <param name="disposeStream">Indicates whether to dispose the baseStream</param>
-    protected StreamWrapper(Stream baseStream, string fileName, DateTime time, bool disposeStream)
+    /// <param name="markOfTheWeb">Zone stream to give the file, or <c>null</c> for none</param>
+    protected StreamWrapper(Stream baseStream, string fileName, DateTime time, bool disposeStream, byte[]? markOfTheWeb)
         : base(disposeStream)
     {
         _baseStream = baseStream;
         _fileName = fileName;
         _fileTime = time;
+        _markOfTheWeb = markOfTheWeb;
     }
 
     /// <summary>
@@ -87,6 +91,10 @@ internal class StreamWrapper : DisposeVariableWrapper, IDisposable
 
         if (!string.IsNullOrEmpty(_fileName) && File.Exists(_fileName))
         {
+            // Writing an alternate data stream touches the base file, so the zone stream
+            // has to go in before the timestamps are restored.
+            MarkOfTheWeb.Apply(_markOfTheWeb, _fileName);
+
             try
             {
                 File.SetLastWriteTime(_fileName, _fileTime);
@@ -207,8 +215,9 @@ internal sealed partial class OutStreamWrapper : StreamWrapper, ISequentialOutSt
     /// <param name="fileName">File name (for attributes fix)</param>
     /// <param name="time">Time of the file creation (for attributes fix)</param>
     /// <param name="disposeStream">Indicates whether to dispose the baseStream</param>
-    public OutStreamWrapper(Stream baseStream, string fileName, DateTime time, bool disposeStream)
-        : base(baseStream, fileName, time, disposeStream)
+    /// <param name="markOfTheWeb">Zone stream to give the file, or <c>null</c> for none</param>
+    public OutStreamWrapper(Stream baseStream, string fileName, DateTime time, bool disposeStream, byte[]? markOfTheWeb)
+        : base(baseStream, fileName, time, disposeStream, markOfTheWeb)
     { }
 
     /// <summary>


### PR DESCRIPTION
Reviewing 26.03, MOTW appeared missing along with other archive-level data.

Two fixes for that, along with another for a test.