### PR TITLE
Properly fill archive properties for every format

### DIFF
--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
@@ -486,6 +486,36 @@ public class SharpSevenZipExtractorTests : TestBase
 
         return target;
     }
+
+    [Test]
+    public void ArchiveWithTrailingDataReportsDataAfterEnd()
+    {
+        // No handler publishes this for Zip: the bytes past the central directory are
+        // simply outside every entry, and only the physical size reveals them.
+        var bytes = File.ReadAllBytes(@"TestData/zip.zip");
+        var archive = Path.Combine(OutputDirectory, "tail.zip");
+        File.WriteAllBytes(archive, bytes.Concat(new byte[4096]).ToArray());
+
+        using var extractor = new SharpSevenZipExtractor(archive);
+
+        Assert.Multiple((Action)delegate
+        {
+            Assert.That(extractor.WarningFlags, Is.EqualTo(ArchiveErrorFlags.DataAfterEnd));
+            Assert.That(extractor.ErrorFlags, Is.EqualTo(ArchiveErrorFlags.None));
+        });
+    }
+
+    [Test]
+    public void ArchiveEndingPastTheStreamReportsUnexpectedEnd()
+    {
+        // VdiHandler has no kpv_ErrorFlags_UnexpectedEnd of its own; it declares a physical
+        // size, and here that size runs past the file.
+        var archive = Truncate(@"TestData/vdi.vdi", "truncated.vdi");
+
+        using var extractor = new SharpSevenZipExtractor(archive);
+
+        Assert.That(extractor.ErrorFlags.HasFlag(ArchiveErrorFlags.UnexpectedEnd), Is.True);
+    }
 }
 
 /// <summary>

--- a/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
+++ b/SharpSevenZip/SharpSevenZip.Tests/SharpSevenZipExtractorTests.cs
@@ -516,6 +516,23 @@ public class SharpSevenZipExtractorTests : TestBase
 
         Assert.That(extractor.ErrorFlags.HasFlag(ArchiveErrorFlags.UnexpectedEnd), Is.True);
     }
+
+    [Test]
+    public void TrailingDataFoundWhileDecodingIsReportedAfterExtraction()
+    {
+        // Gz publishes no physical size before decoding and sets its own flag only while it
+        // runs, so the open has nothing to say about the tail.
+        var bytes = File.ReadAllBytes(@"TestData/gzip.gz");
+        var archive = Path.Combine(OutputDirectory, "tail.gz");
+        File.WriteAllBytes(archive, bytes.Concat(new byte[4096]).ToArray());
+
+        using var extractor = new SharpSevenZipExtractor(archive);
+        Assert.That(extractor.ErrorFlags, Is.EqualTo(ArchiveErrorFlags.None));
+
+        extractor.ExtractArchive(OutputDirectory);
+
+        Assert.That(extractor.ErrorFlags, Is.EqualTo(ArchiveErrorFlags.DataAfterEnd));
+    }
 }
 
 /// <summary>

--- a/SharpSevenZip/SharpSevenZip/ArchiveErrorFlags.cs
+++ b/SharpSevenZip/SharpSevenZip/ArchiveErrorFlags.cs
@@ -43,7 +43,8 @@ public enum ArchiveErrorFlags
     UnexpectedEnd = 1 << 5,
 
     /// <summary>
-    /// The archive is followed by data that is not part of it.
+    /// The archive is followed by data that is not part of it. Only a few handlers report
+    /// this themselves; for the rest it is measured against the physical size.
     /// </summary>
     DataAfterEnd = 1 << 6,
 

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
@@ -591,24 +591,7 @@ public sealed partial class SharpSevenZipExtractor
 
                 try
                 {
-                    #region Getting archive diagnostics
-
-                    // No handler lists these among its archive properties, so they can only
-                    // be asked for by id.
-                    _archive.GetArchiveProperty(ItemPropId.ErrorFlags, ref data);
-                    _errorFlags = (ArchiveErrorFlags)NativeMethods.SafeCast<uint>(data, 0);
-                    _archive.GetArchiveProperty(ItemPropId.WarningFlags, ref data);
-                    _warningFlags = (ArchiveErrorFlags)NativeMethods.SafeCast<uint>(data, 0);
-                    _archive.GetArchiveProperty(ItemPropId.Error, ref data);
-                    _errorMessage = NativeMethods.SafeCast<string?>(data, null);
-                    _archive.GetArchiveProperty(ItemPropId.Warning, ref data);
-                    _warningMessage = NativeMethods.SafeCast<string?>(data, null);
-                    _archive.GetArchiveProperty(ItemPropId.PhysicalSize, ref data);
-                    var physicalSize = NumericProperty(data);
-                    _archive.GetArchiveProperty(ItemPropId.Offset, ref data);
-                    CheckArchiveBounds(physicalSize, NumericProperty(data));
-
-                    #endregion
+                    ReadDiagnostics();
 
                     if (_filesCount != 0)
                     {
@@ -717,6 +700,28 @@ public sealed partial class SharpSevenZipExtractor
 
             _archiveFileInfoCollection = new ReadOnlyCollection<ArchiveFileInfo>(_archiveFileData);
         }
+    }
+
+    /// <summary>
+    /// Reads what 7-Zip reports about the opened archive. None of these appear in a handler's
+    /// enumerated archive-property list, so they can only be asked for by id.
+    /// </summary>
+    private void ReadDiagnostics()
+    {
+        var data = new PropVariant();
+
+        _archive!.GetArchiveProperty(ItemPropId.ErrorFlags, ref data);
+        _errorFlags = (ArchiveErrorFlags)NativeMethods.SafeCast<uint>(data, 0);
+        _archive.GetArchiveProperty(ItemPropId.WarningFlags, ref data);
+        _warningFlags = (ArchiveErrorFlags)NativeMethods.SafeCast<uint>(data, 0);
+        _archive.GetArchiveProperty(ItemPropId.Error, ref data);
+        _errorMessage = NativeMethods.SafeCast<string?>(data, null);
+        _archive.GetArchiveProperty(ItemPropId.Warning, ref data);
+        _warningMessage = NativeMethods.SafeCast<string?>(data, null);
+        _archive.GetArchiveProperty(ItemPropId.PhysicalSize, ref data);
+        var physicalSize = NumericProperty(data);
+        _archive.GetArchiveProperty(ItemPropId.Offset, ref data);
+        CheckArchiveBounds(physicalSize, NumericProperty(data));
     }
 
     /// <summary>
@@ -874,6 +879,21 @@ public sealed partial class SharpSevenZipExtractor
     private void FreeArchiveExtractCallback(ArchiveExtractCallback callback)
     {
         HasDataAfterEnd |= callback.HasDataAfterEnd;
+
+        // gz, bz2, xz and zstd publish no physical size before decoding and only learn about
+        // trailing or missing data while it runs, so what was read at open time is stale.
+        if (_archive != null)
+        {
+            try
+            {
+                ReadDiagnostics();
+            }
+            catch (Exception)
+            {
+                // Keep what the open reported.
+            }
+        }
+
         callback.Open -= OpenEventProxy;
         callback.FileExtractionStarted -= FileExtractionStartedEventProxy;
         callback.FileExtractionFinished -= FileExtractionFinishedEventProxy;

--- a/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
+++ b/SharpSevenZip/SharpSevenZip/SharpSevenZipExtractor.cs
@@ -603,6 +603,10 @@ public sealed partial class SharpSevenZipExtractor
                     _errorMessage = NativeMethods.SafeCast<string?>(data, null);
                     _archive.GetArchiveProperty(ItemPropId.Warning, ref data);
                     _warningMessage = NativeMethods.SafeCast<string?>(data, null);
+                    _archive.GetArchiveProperty(ItemPropId.PhysicalSize, ref data);
+                    var physicalSize = NumericProperty(data);
+                    _archive.GetArchiveProperty(ItemPropId.Offset, ref data);
+                    CheckArchiveBounds(physicalSize, NumericProperty(data));
 
                     #endregion
 
@@ -712,6 +716,68 @@ public sealed partial class SharpSevenZipExtractor
             }
 
             _archiveFileInfoCollection = new ReadOnlyCollection<ArchiveFileInfo>(_archiveFileData);
+        }
+    }
+
+    /// <summary>
+    /// Numeric archive properties arrive as VT_UI8, VT_UI4, VT_I8 or VT_I4 depending on the
+    /// handler. A value above <see cref="long.MaxValue"/> cannot describe a readable stream
+    /// and is reported as -1 so the caller discards it.
+    /// </summary>
+    private static long NumericProperty(PropVariant data)
+    {
+        object? value;
+
+        try
+        {
+            value = data.Object;
+        }
+        catch (Exception)
+        {
+            return 0;
+        }
+
+        return value switch
+        {
+            ulong v => v <= long.MaxValue ? (long)v : -1,
+            long v => v,
+            uint v => v,
+            int v => v,
+            _ => 0
+        };
+    }
+
+    /// <summary>
+    /// Compares the archive's physical end against the stream, as CArc::ReadBasicProps does.
+    /// Neither verdict is an archive property: for Zip, 7z and PE the handlers publish a
+    /// physical size and leave the conclusion to the caller. Bytes past that end belong to no
+    /// entry, and an end past the stream means the archive is short.
+    /// </summary>
+    private void CheckArchiveBounds(long physicalSize, long handlerOffset)
+    {
+        var total = _packedSize ?? (_fileName != null ? new FileInfo(_fileName).Length : -1);
+
+        // 7-Zip splits the archive start the same way: the position the handler's stream was
+        // opened at, plus the offset a kUseGlobalOffset handler reports for itself.
+        var start = _offset + handlerOffset;
+
+        if (physicalSize <= 0 || total < 0 || start < 0)
+        {
+            return;
+        }
+
+        var available = total - start;
+
+        if (physicalSize < available)
+        {
+            if ((_errorFlags & ArchiveErrorFlags.DataAfterEnd) == 0)
+            {
+                _warningFlags |= ArchiveErrorFlags.DataAfterEnd;
+            }
+        }
+        else if (physicalSize > available)
+        {
+            _errorFlags |= ArchiveErrorFlags.UnexpectedEnd;
         }
     }
 
@@ -1046,6 +1112,8 @@ public sealed partial class SharpSevenZipExtractor
     /// Gets the problems 7-Zip reported for the archive. Anything other than
     /// <see cref="ArchiveErrorFlags.None"/> means the archive cannot be extracted in full,
     /// even when extraction itself reports no failure.
+    /// <see cref="ArchiveErrorFlags.UnexpectedEnd"/> is also raised when the physical size
+    /// runs past the stream, which is where 7-Zip's own tools derive it from.
     /// </summary>
     public ArchiveErrorFlags ErrorFlags
     {
@@ -1060,6 +1128,8 @@ public sealed partial class SharpSevenZipExtractor
 
     /// <summary>
     /// Gets the non-fatal problems 7-Zip reported for the archive.
+    /// <see cref="ArchiveErrorFlags.DataAfterEnd"/> is measured against the physical size
+    /// rather than taken from a handler, which is where 7-Zip's own tools get it from.
     /// </summary>
     public ArchiveErrorFlags WarningFlags
     {


### PR DESCRIPTION
Two oversights fixed concerning the archive properties added in the last pull request.